### PR TITLE
feat: add tabular domain models

### DIFF
--- a/lib/domain/README.md
+++ b/lib/domain/README.md
@@ -1,0 +1,24 @@
+# Domaine tableur
+
+Ce module expose trois entités immuables :
+
+- **Workbook** : regroupe plusieurs feuilles. Les noms de feuille doivent être
+  uniques (`Sheet.name`) et au moins une feuille doit être présente.
+- **Sheet** : représente une grille rectangulaire. Chaque feuille doit avoir au
+  moins une ligne et une colonne. Toutes les lignes partagent la même largeur et
+  les cellules absentes sont modélisées via des `Cell` de type `empty`.
+- **Cell** : décrit la valeur d'une case avec son type (`empty`, `text`,
+  `number`, `boolean`). Le type est toujours cohérent avec la valeur runtime.
+
+La sérialisation CSV expose deux stratégies :
+
+- `Sheet.toCsv` / `Sheet.fromCsv` pour manipuler une feuille à la fois.
+- `Workbook.toCsvMap` / `Workbook.fromCsvMap` pour gérer un ensemble de feuilles
+  (le format map facilite l'export multi-fichiers).
+
+Les conversions depuis le CSV respectent les règles suivantes :
+
+- Les champs vides deviennent des cellules `empty`.
+- `TRUE` / `FALSE` sont convertis en booléens (insensibles à la casse).
+- Les nombres sont déduits via `num.tryParse`.
+- Tout autre contenu reste textuel.

--- a/lib/domain/cell.dart
+++ b/lib/domain/cell.dart
@@ -1,0 +1,119 @@
+import 'package:meta/meta.dart';
+
+/// Represents the kind of value carried by a [Cell].
+enum CellType {
+  /// Empty cells hold no value and serialise to an empty CSV field.
+  empty,
+
+  /// Textual values serialise exactly as written.
+  text,
+
+  /// Numeric values are stored as [num] and serialise using [num.toString()].
+  number,
+
+  /// Boolean values serialise to `TRUE` or `FALSE`.
+  boolean,
+}
+
+/// A single cell within a [Sheet].
+///
+/// The class keeps track of the position to ease validation and rehydration.
+@immutable
+class Cell {
+  const Cell({
+    required this.row,
+    required this.column,
+    required this.type,
+    this.value,
+  }) : assert(row >= 0 && column >= 0, 'Cell coordinates must be >= 0.');
+
+  /// Zero-based row index.
+  final int row;
+
+  /// Zero-based column index.
+  final int column;
+
+  /// The declared type of [value].
+  final CellType type;
+
+  /// The raw value. The runtime type matches [type].
+  final Object? value;
+
+  /// Creates a [Cell] by inspecting [value] to determine an appropriate [CellType].
+  factory Cell.fromValue({
+    required int row,
+    required int column,
+    Object? value,
+  }) {
+    if (value == null || (value is String && value.isEmpty)) {
+      return Cell(row: row, column: column, type: CellType.empty, value: null);
+    }
+
+    if (value is bool) {
+      return Cell(row: row, column: column, type: CellType.boolean, value: value);
+    }
+
+    if (value is num) {
+      return Cell(row: row, column: column, type: CellType.number, value: value);
+    }
+
+    return Cell(
+      row: row,
+      column: column,
+      type: CellType.text,
+      value: value.toString(),
+    );
+  }
+
+  /// Converts a CSV field into a [Cell].
+  ///
+  /// Empty fields produce [CellType.empty] cells. `TRUE`/`FALSE` map to
+  /// [CellType.boolean]. Numeric strings are parsed as [num]. Everything else is
+  /// kept as text.
+  factory Cell.fromCsvField({
+    required int row,
+    required int column,
+    required String field,
+  }) {
+    if (field.isEmpty) {
+      return Cell.fromValue(row: row, column: column, value: null);
+    }
+
+    final normalised = field.trim();
+    if (normalised.isEmpty) {
+      return Cell.fromValue(row: row, column: column, value: '');
+    }
+
+    if (normalised.toUpperCase() == 'TRUE') {
+      return Cell.fromValue(row: row, column: column, value: true);
+    }
+
+    if (normalised.toUpperCase() == 'FALSE') {
+      return Cell.fromValue(row: row, column: column, value: false);
+    }
+
+    final numeric = num.tryParse(normalised);
+    if (numeric != null) {
+      return Cell.fromValue(row: row, column: column, value: numeric);
+    }
+
+    return Cell.fromValue(row: row, column: column, value: field);
+  }
+
+  /// Serialises the cell to a CSV-compatible field string.
+  String toCsvField() {
+    switch (type) {
+      case CellType.empty:
+        return '';
+      case CellType.boolean:
+        return (value as bool) ? 'TRUE' : 'FALSE';
+      case CellType.number:
+        return (value as num).toString();
+      case CellType.text:
+        return value.toString();
+    }
+  }
+
+  /// Returns the runtime value casted to the expected Dart type for [type].
+  T? typedValue<T>() => value as T?;
+}

--- a/lib/domain/sheet.dart
+++ b/lib/domain/sheet.dart
@@ -1,0 +1,121 @@
+import 'package:csv/csv.dart';
+import 'package:meta/meta.dart';
+
+import 'cell.dart';
+
+/// A tabular collection of [Cell]s within a [Workbook].
+///
+/// Invariants:
+/// * A sheet must expose at least one row and one column. Empty sheets are not
+///   supported and should instead be omitted from the workbook.
+/// * All rows must have the same number of columns. Gaps are represented by
+///   [CellType.empty] cells.
+@immutable
+class Sheet {
+  Sheet({
+    required this.name,
+    required List<List<Cell>> rows,
+  })  : assert(name.isNotEmpty, 'Sheets must be named.'),
+        assert(rows.isNotEmpty, 'A sheet must contain at least one row.'),
+        assert(
+          rows.every((row) => row.length == rows.first.length),
+          'All rows must have the same column count.',
+        ),
+        _rows = rows
+            .map((row) => List<Cell>.unmodifiable(row))
+            .toList(growable: false);
+
+  /// Unique sheet name inside its workbook.
+  final String name;
+
+  final List<List<Cell>> _rows;
+
+  /// Access to the rows as an immutable list.
+  List<List<Cell>> get rows =>
+      _rows.map((row) => List<Cell>.unmodifiable(row)).toList(growable: false);
+
+  /// Number of rows.
+  int get rowCount => _rows.length;
+
+  /// Number of columns.
+  int get columnCount => _rows.isEmpty ? 0 : _rows.first.length;
+
+  /// Serialises the sheet to CSV text.
+  ///
+  /// The default CSV codec is used and matches Excel/Google Sheets escaping
+  /// behaviour.
+  String toCsv({String fieldDelimiter = ',', String eol = '\n'}) {
+    final converter = const ListToCsvConverter();
+    final table = _rows
+        .map(
+          (row) => row
+              .map(
+                (cell) => cell.toCsvField(),
+              )
+              .toList(growable: false),
+        )
+        .toList(growable: false);
+    return converter.convert(
+      table,
+      fieldDelimiter: fieldDelimiter,
+      eol: eol,
+    );
+  }
+
+  /// Builds a [Sheet] from CSV data.
+  factory Sheet.fromCsv({
+    required String name,
+    required String csv,
+    String fieldDelimiter = ',',
+  }) {
+    final converter = const CsvToListConverter(shouldParseNumbers: false);
+    final rows = converter.convert(csv, fieldDelimiter: fieldDelimiter);
+    if (rows.isEmpty) {
+      throw const FormatException('A sheet must contain at least one row.');
+    }
+
+    final normalisedRows = <List<Cell>>[];
+    for (var r = 0; r < rows.length; r++) {
+      final row = rows[r];
+      final cells = <Cell>[];
+      for (var c = 0; c < row.length; c++) {
+        final field = row[c];
+        if (field is String) {
+          cells.add(Cell.fromCsvField(row: r, column: c, field: field));
+        } else if (field is num) {
+          cells.add(Cell.fromValue(row: r, column: c, value: field));
+        } else if (field is bool) {
+          cells.add(Cell.fromValue(row: r, column: c, value: field));
+        } else {
+          cells.add(Cell.fromValue(row: r, column: c, value: field.toString()));
+        }
+      }
+
+      normalisedRows.add(List<Cell>.unmodifiable(cells));
+    }
+
+    if (normalisedRows.first.isEmpty) {
+      throw const FormatException('A sheet must contain at least one column.');
+    }
+
+    return Sheet(name: name, rows: normalisedRows);
+  }
+
+  /// Creates a sheet using string rows. Convenience for tests/fixtures.
+  factory Sheet.fromRows({
+    required String name,
+    required List<List<Object?>> rows,
+  }) {
+    final normalisedRows = <List<Cell>>[];
+    for (var r = 0; r < rows.length; r++) {
+      final row = rows[r];
+      final cells = <Cell>[];
+      for (var c = 0; c < row.length; c++) {
+        cells.add(Cell.fromValue(row: r, column: c, value: row[c]));
+      }
+      normalisedRows.add(List<Cell>.unmodifiable(cells));
+    }
+
+    return Sheet(name: name, rows: normalisedRows);
+  }
+}

--- a/lib/domain/workbook.dart
+++ b/lib/domain/workbook.dart
@@ -1,0 +1,62 @@
+import 'package:meta/meta.dart';
+
+import 'sheet.dart';
+
+/// Represents a spreadsheet workbook.
+///
+/// Invariants:
+/// * Sheet names are unique.
+/// * A workbook exposes at least one sheet to remain meaningful.
+@immutable
+class Workbook {
+  Workbook({
+    required List<Sheet> sheets,
+  })  : assert(sheets.isNotEmpty, 'A workbook must contain at least one sheet.'),
+        assert(
+          _areSheetNamesUnique(sheets),
+          'Sheet names must be unique.',
+        ),
+        _sheets = List<Sheet>.unmodifiable(sheets);
+
+  final List<Sheet> _sheets;
+
+  /// Immutable view on the sheets.
+  List<Sheet> get sheets => _sheets;
+
+  /// Serialises the workbook to CSV per sheet.
+  ///
+  /// Each entry in the resulting map uses the sheet name as key and the CSV
+  /// representation as value. Consumers can persist the map or recombine the
+  /// values into archive formats (zip, etc.).
+  Map<String, String> toCsvMap({String fieldDelimiter = ',', String eol = '\n'}) {
+    return {
+      for (final sheet in _sheets)
+        sheet.name: sheet.toCsv(fieldDelimiter: fieldDelimiter, eol: eol),
+    };
+  }
+
+  /// Builds a workbook from CSV chunks.
+  factory Workbook.fromCsvMap(Map<String, String> csvSheets) {
+    if (csvSheets.isEmpty) {
+      throw const FormatException('A workbook must contain at least one sheet.');
+    }
+
+    final sheets = csvSheets.entries
+        .map(
+          (entry) => Sheet.fromCsv(name: entry.key, csv: entry.value),
+        )
+        .toList(growable: false);
+
+    return Workbook(sheets: sheets);
+  }
+
+  static bool _areSheetNamesUnique(List<Sheet> sheets) {
+    final seen = <String>{};
+    for (final sheet in sheets) {
+      if (!seen.add(sheet.name)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  csv: ^5.0.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add immutable Cell, Sheet, and Workbook domain models with CSV serialization helpers
- document type and dimension invariants for the tabular domain module
- pull in the csv dependency to leverage Dart CSV codecs

## Testing
- ⚠️ `flutter pub get` *(fails: Flutter SDK is not available in the environment)*
- ⚠️ `dart format lib/domain` *(fails: Dart SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dca2e3ac288326b7375c45e0eea1b5