### PR TITLE
Add CSV service for workbook serialization

### DIFF
--- a/lib/services/csv_service.dart
+++ b/lib/services/csv_service.dart
@@ -1,0 +1,157 @@
+import 'dart:io';
+
+import 'package:csv/csv.dart';
+
+import '../domain/cell.dart';
+import '../domain/sheet.dart';
+import '../domain/workbook.dart';
+
+/// Converts raw CSV fields into typed [Cell] instances and back.
+class CsvCellFactory {
+  const CsvCellFactory();
+
+  /// Builds a [Cell] from the raw field emitted by the CSV parser.
+  Cell fromField({
+    required int row,
+    required int column,
+    required dynamic field,
+  }) {
+    if (field == null) {
+      return Cell.fromValue(row: row, column: column, value: null);
+    }
+
+    if (field is bool || field is num) {
+      return Cell.fromValue(row: row, column: column, value: field);
+    }
+
+    if (field is String) {
+      if (field.isEmpty) {
+        return Cell.fromValue(row: row, column: column, value: null);
+      }
+
+      final normalised = field.trim();
+      final upper = normalised.toUpperCase();
+      if (upper == 'TRUE') {
+        return Cell.fromValue(row: row, column: column, value: true);
+      }
+      if (upper == 'FALSE') {
+        return Cell.fromValue(row: row, column: column, value: false);
+      }
+
+      final numeric = num.tryParse(normalised);
+      if (numeric != null) {
+        return Cell.fromValue(row: row, column: column, value: numeric);
+      }
+
+      return Cell.fromValue(row: row, column: column, value: field);
+    }
+
+    return Cell.fromValue(
+      row: row,
+      column: column,
+      value: field.toString(),
+    );
+  }
+
+  /// Serialises a [Cell] to a CSV compatible field.
+  String toField(Cell cell) => cell.toCsvField();
+}
+
+/// Provides helpers to load and save [Workbook] instances using CSV files.
+class CsvService {
+  const CsvService({CsvCellFactory? cellFactory})
+      : _cellFactory = cellFactory ?? const CsvCellFactory();
+
+  final CsvCellFactory _cellFactory;
+
+  /// Loads a [Workbook] from a CSV [file].
+  ///
+  /// The service produces a workbook exposing a single sheet. The sheet name can
+  /// be customised via [sheetName].
+  Future<Workbook> loadFromCsv({
+    required File file,
+    String sheetName = 'Sheet1',
+    String fieldDelimiter = ',',
+  }) async {
+    final raw = await file.readAsString();
+    final converter = const CsvToListConverter(
+      shouldParseNumbers: false,
+      shouldParseNulls: false,
+    );
+
+    List<List<dynamic>> rows;
+    try {
+      rows = converter.convert(raw, fieldDelimiter: fieldDelimiter);
+    } on FormatException catch (error) {
+      throw FormatException('Invalid CSV content: ${error.message}');
+    }
+
+    if (rows.isEmpty) {
+      throw const FormatException('CSV data must contain at least one row.');
+    }
+
+    final expectedColumnCount = rows.first.length;
+    if (expectedColumnCount == 0) {
+      throw const FormatException('CSV data must contain at least one column.');
+    }
+
+    final normalisedRows = <List<Cell>>[];
+    for (var r = 0; r < rows.length; r++) {
+      final row = rows[r];
+      if (row.length != expectedColumnCount) {
+        throw FormatException(
+          'Row ${r + 1} has ${row.length} columns, expected '
+          '$expectedColumnCount.',
+        );
+      }
+
+      final cells = <Cell>[];
+      for (var c = 0; c < row.length; c++) {
+        cells.add(
+          _cellFactory.fromField(row: r, column: c, field: row[c]),
+        );
+      }
+      normalisedRows.add(List<Cell>.unmodifiable(cells));
+    }
+
+    final sheet = Sheet(name: sheetName, rows: normalisedRows);
+    return Workbook(sheets: [sheet]);
+  }
+
+  /// Persists a [workbook] to [file] using CSV format.
+  ///
+  /// Only single-sheet workbooks are supported as CSV does not support
+  /// multi-sheet data.
+  Future<void> saveToCsv({
+    required Workbook workbook,
+    required File file,
+    String fieldDelimiter = ',',
+    String eol = '\n',
+  }) async {
+    if (workbook.sheets.length != 1) {
+      throw ArgumentError(
+        'CSV serialisation expects a workbook with exactly one sheet.',
+      );
+    }
+
+    final sheet = workbook.sheets.first;
+    final table = sheet.rows
+        .map(
+          (row) => row
+              .map(
+                (cell) => _cellFactory.toField(cell),
+              )
+              .toList(growable: false),
+        )
+        .toList(growable: false);
+
+    final converter = const ListToCsvConverter();
+    final csv = converter.convert(
+      table,
+      fieldDelimiter: fieldDelimiter,
+      eol: eol,
+    );
+
+    await file.writeAsString(csv);
+  }
+}

--- a/test/services/csv_service_test.dart
+++ b/test/services/csv_service_test.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+
+import 'package:csv/csv.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_application_1/domain/cell.dart';
+import 'package:flutter_application_1/domain/sheet.dart';
+import 'package:flutter_application_1/domain/workbook.dart';
+import 'package:flutter_application_1/services/csv_service.dart';
+
+void main() {
+  group('CsvService', () {
+    late Directory tempDir;
+    late CsvService service;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('csv_service_test');
+      service = const CsvService();
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('loadFromCsv parses values with custom delimiter', () async {
+      final file = File('${tempDir.path}/people.csv');
+      await file.writeAsString('Name;Age;Active\nAlice;42;TRUE\nBob;27;FALSE');
+
+      final workbook = await service.loadFromCsv(
+        file: file,
+        sheetName: 'People',
+        fieldDelimiter: ';',
+      );
+
+      final sheet = workbook.sheets.single;
+      expect(sheet.name, 'People');
+      expect(sheet.rowCount, 3);
+      expect(sheet.columnCount, 3);
+
+      final rows = sheet.rows;
+      expect(rows[1][1].type, CellType.number);
+      expect(rows[1][1].value, 42);
+      expect(rows[1][2].type, CellType.boolean);
+      expect(rows[1][2].value, true);
+      expect(rows[2][2].value, false);
+    });
+
+    test('saveToCsv persists typed cells using the delimiter', () async {
+      final workbook = Workbook(
+        sheets: [
+          Sheet.fromRows(
+            name: 'Notes',
+            rows: [
+              ['Name', 'Comment'],
+              ['Alice', 'Hello, world'],
+              ['Bob', 'Says "Hi"'],
+            ],
+          ),
+        ],
+      );
+
+      final file = File('${tempDir.path}/notes.csv');
+      await service.saveToCsv(
+        workbook: workbook,
+        file: file,
+        fieldDelimiter: ';',
+      );
+
+      final contents = await file.readAsString();
+      final parsed = const CsvToListConverter(shouldParseNumbers: false)
+          .convert(contents, fieldDelimiter: ';');
+
+      expect(parsed.length, 3);
+      expect(parsed[1][1], 'Hello, world');
+      expect(parsed[2][1], 'Says "Hi"');
+    });
+
+    test('loadFromCsv throws when delimiters are inconsistent', () async {
+      final file = File('${tempDir.path}/broken.csv');
+      await file.writeAsString('A,B\n1;2');
+
+      expect(
+        () => service.loadFromCsv(file: file),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('loadFromCsv propagates malformed quotes', () async {
+      final file = File('${tempDir.path}/quote.csv');
+      await file.writeAsString('Name,Quote\nAlice,"Hello');
+
+      expect(
+        () => service.loadFromCsv(file: file),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('loadFromCsv rejects rows with variable lengths', () async {
+      final file = File('${tempDir.path}/variable.csv');
+      await file.writeAsString('A,B\n1,2\n3');
+
+      expect(
+        () => service.loadFromCsv(file: file),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a CSV service with a conversion factory to load and save single-sheet workbooks
- validate inconsistent delimiters, malformed quotes, and varying row lengths during parsing
- cover the service with unit tests for nominal scenarios and failure cases

## Testing
- ⚠️ flutter test *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcabd835588326bedbc98addaf2704