### PR TITLE
Add command ribbon and workbook command framework

### DIFF
--- a/lib/application/commands/add_sheet_command.dart
+++ b/lib/application/commands/add_sheet_command.dart
@@ -1,0 +1,52 @@
+import '../../domain/cell.dart';
+import '../../domain/sheet.dart';
+import '../../domain/workbook.dart';
+import 'workbook_command.dart';
+
+class AddSheetCommand extends WorkbookCommand {
+  const AddSheetCommand({this.rowCount = 20, this.columnCount = 8});
+
+  final int rowCount;
+  final int columnCount;
+
+  @override
+  String get label => 'Nouvelle feuille';
+
+  @override
+  WorkbookCommandResult execute(WorkbookCommandContext context) {
+    final newSheetName = _generateSheetName(context.workbook);
+    final rows = List<List<Cell>>.generate(
+      rowCount,
+      (row) => List<Cell>.generate(
+        columnCount,
+        (column) =>
+            Cell(row: row, column: column, type: CellType.empty, value: null),
+      ),
+      growable: false,
+    );
+
+    final newSheet = Sheet(name: newSheetName, rows: rows);
+    final sheets = context.workbook.sheets.toList(growable: true)..add(newSheet);
+    final updatedWorkbook = Workbook(sheets: sheets);
+    final newIndex = sheets.length - 1;
+
+    return WorkbookCommandResult(
+      workbook: updatedWorkbook,
+      activeSheetIndex: newIndex,
+    );
+  }
+
+  String _generateSheetName(Workbook workbook) {
+    const prefix = 'Feuille ';
+    var highest = 0;
+    for (final sheet in workbook.sheets) {
+      if (sheet.name.startsWith(prefix)) {
+        final maybeNumber = int.tryParse(sheet.name.substring(prefix.length));
+        if (maybeNumber != null && maybeNumber > highest) {
+          highest = maybeNumber;
+        }
+      }
+    }
+    return '$prefix${highest + 1}';
+  }
+}

--- a/lib/application/commands/clear_sheet_command.dart
+++ b/lib/application/commands/clear_sheet_command.dart
@@ -1,0 +1,40 @@
+import '../../domain/cell.dart';
+import '../../domain/sheet.dart';
+import '../../domain/workbook.dart';
+import 'command_utils.dart';
+import 'workbook_command.dart';
+
+class ClearSheetCommand extends WorkbookCommand {
+  const ClearSheetCommand();
+
+  @override
+  String get label => 'Effacer les données';
+
+  @override
+  bool canExecute(WorkbookCommandContext context) {
+    final sheet = context.activeSheet;
+    return sheet != null && sheet.rowCount > 0 && sheet.columnCount > 0;
+  }
+
+  @override
+  WorkbookCommandResult execute(WorkbookCommandContext context) {
+    final sheet = context.activeSheet;
+    if (sheet == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    final rows = cloneSheetRows(sheet);
+    for (var r = 0; r < rows.length; r++) {
+      final row = rows[r];
+      for (var c = 0; c < row.length; c++) {
+        row[c] = Cell(row: r, column: c, type: CellType.empty, value: null);
+      }
+    }
+
+    final updatedSheet = rebuildSheetFromRows(sheet, rows);
+    final Workbook updatedWorkbook =
+        replaceSheet(context.workbook, context.activeSheetIndex, updatedSheet);
+
+    return WorkbookCommandResult(workbook: updatedWorkbook);
+  }
+}

--- a/lib/application/commands/command_utils.dart
+++ b/lib/application/commands/command_utils.dart
@@ -1,0 +1,33 @@
+import '../../domain/cell.dart';
+import '../../domain/sheet.dart';
+import '../../domain/workbook.dart';
+
+List<List<Cell>> cloneSheetRows(Sheet sheet) {
+  final rows = <List<Cell>>[];
+  for (var r = 0; r < sheet.rows.length; r++) {
+    final row = sheet.rows[r];
+    rows.add([
+      for (var c = 0; c < row.length; c++)
+        Cell(row: r, column: c, type: row[c].type, value: row[c].value)
+    ]);
+  }
+  return rows;
+}
+
+List<Cell> buildEmptyRow(int rowIndex, int columnCount) {
+  return List<Cell>.generate(
+    columnCount,
+    (column) =>
+        Cell(row: rowIndex, column: column, type: CellType.empty, value: null),
+  );
+}
+
+Workbook replaceSheet(Workbook workbook, int sheetIndex, Sheet newSheet) {
+  final sheets = workbook.sheets.toList(growable: true);
+  sheets[sheetIndex] = newSheet;
+  return Workbook(sheets: sheets);
+}
+
+Sheet rebuildSheetFromRows(Sheet template, List<List<Cell>> rows) {
+  return Sheet(name: template.name, rows: rows);
+}

--- a/lib/application/commands/insert_row_command.dart
+++ b/lib/application/commands/insert_row_command.dart
@@ -1,0 +1,35 @@
+import '../../domain/sheet.dart';
+import '../../domain/workbook.dart';
+import 'command_utils.dart';
+import 'workbook_command.dart';
+
+class InsertRowCommand extends WorkbookCommand {
+  const InsertRowCommand();
+
+  @override
+  String get label => 'Insérer une ligne';
+
+  @override
+  bool canExecute(WorkbookCommandContext context) {
+    final sheet = context.activeSheet;
+    return sheet != null && sheet.columnCount > 0;
+  }
+
+  @override
+  WorkbookCommandResult execute(WorkbookCommandContext context) {
+    final sheet = context.activeSheet;
+    if (sheet == null || sheet.columnCount == 0) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    final rows = cloneSheetRows(sheet);
+    final newRowIndex = rows.length;
+    rows.add(buildEmptyRow(newRowIndex, sheet.columnCount));
+
+    final updatedSheet = rebuildSheetFromRows(sheet, rows);
+    final Workbook updatedWorkbook =
+        replaceSheet(context.workbook, context.activeSheetIndex, updatedSheet);
+
+    return WorkbookCommandResult(workbook: updatedWorkbook);
+  }
+}

--- a/lib/application/commands/populate_sample_data_command.dart
+++ b/lib/application/commands/populate_sample_data_command.dart
@@ -1,0 +1,55 @@
+import '../../domain/cell.dart';
+import '../../domain/sheet.dart';
+import '../../domain/workbook.dart';
+import 'command_utils.dart';
+import 'workbook_command.dart';
+
+class PopulateSampleDataCommand extends WorkbookCommand {
+  const PopulateSampleDataCommand();
+
+  @override
+  String get label => 'Données d\'exemple';
+
+  @override
+  bool canExecute(WorkbookCommandContext context) {
+    final sheet = context.activeSheet;
+    return sheet != null && sheet.columnCount > 0;
+  }
+
+  @override
+  WorkbookCommandResult execute(WorkbookCommandContext context) {
+    final sheet = context.activeSheet;
+    if (sheet == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    const sample = <List<Object?>>[
+      ['Nom', 'Âge', 'Ville', 'Profession'],
+      ['Alice', 29, 'Paris', 'Designer'],
+      ['Bob', 35, 'Lyon', 'Développeur'],
+    ];
+
+    final rows = cloneSheetRows(sheet);
+    final requiredRows = sample.length;
+    final columnCount = sheet.columnCount;
+
+    while (rows.length < requiredRows) {
+      rows.add(buildEmptyRow(rows.length, columnCount));
+    }
+
+    for (var r = 0; r < sample.length; r++) {
+      final row = rows[r];
+      final dataRow = sample[r];
+      final limit = dataRow.length < row.length ? dataRow.length : row.length;
+      for (var c = 0; c < limit; c++) {
+        row[c] = Cell.fromValue(row: r, column: c, value: dataRow[c]);
+      }
+    }
+
+    final updatedSheet = rebuildSheetFromRows(sheet, rows);
+    final Workbook updatedWorkbook =
+        replaceSheet(context.workbook, context.activeSheetIndex, updatedSheet);
+
+    return WorkbookCommandResult(workbook: updatedWorkbook);
+  }
+}

--- a/lib/application/commands/remove_sheet_command.dart
+++ b/lib/application/commands/remove_sheet_command.dart
@@ -1,0 +1,40 @@
+import '../../domain/workbook.dart';
+import 'workbook_command.dart';
+
+class RemoveSheetCommand extends WorkbookCommand {
+  const RemoveSheetCommand({this.sheetIndex});
+
+  final int? sheetIndex;
+
+  const RemoveSheetCommand.forIndex(int index) : sheetIndex = index;
+
+  @override
+  String get label => 'Supprimer la feuille';
+
+  @override
+  bool canExecute(WorkbookCommandContext context) {
+    final index = sheetIndex ?? context.activeSheetIndex;
+    return context.workbook.sheets.length > 1 &&
+        index >= 0 &&
+        index < context.workbook.sheets.length;
+  }
+
+  @override
+  WorkbookCommandResult execute(WorkbookCommandContext context) {
+    final index = sheetIndex ?? context.activeSheetIndex;
+    if (!canExecute(context)) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    final sheets = context.workbook.sheets.toList(growable: true)
+      ..removeAt(index);
+    final updatedWorkbook = Workbook(sheets: sheets);
+
+    final newActiveIndex = index.clamp(0, sheets.length - 1);
+
+    return WorkbookCommandResult(
+      workbook: updatedWorkbook,
+      activeSheetIndex: newActiveIndex,
+    );
+  }
+}

--- a/lib/application/commands/uppercase_header_command.dart
+++ b/lib/application/commands/uppercase_header_command.dart
@@ -1,0 +1,46 @@
+import '../../domain/cell.dart';
+import '../../domain/sheet.dart';
+import '../../domain/workbook.dart';
+import 'command_utils.dart';
+import 'workbook_command.dart';
+
+class UppercaseHeaderCommand extends WorkbookCommand {
+  const UppercaseHeaderCommand();
+
+  @override
+  String get label => 'Entêtes en majuscules';
+
+  @override
+  bool canExecute(WorkbookCommandContext context) {
+    final sheet = context.activeSheet;
+    return sheet != null && sheet.rowCount > 0 && sheet.columnCount > 0;
+  }
+
+  @override
+  WorkbookCommandResult execute(WorkbookCommandContext context) {
+    final sheet = context.activeSheet;
+    if (sheet == null || sheet.rowCount == 0) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    final rows = cloneSheetRows(sheet);
+    final headerRow = rows.first;
+    for (var c = 0; c < headerRow.length; c++) {
+      final cell = headerRow[c];
+      if (cell.type == CellType.text) {
+        headerRow[c] = Cell(
+          row: 0,
+          column: c,
+          type: CellType.text,
+          value: (cell.value as String).toUpperCase(),
+        );
+      }
+    }
+
+    final updatedSheet = rebuildSheetFromRows(sheet, rows);
+    final Workbook updatedWorkbook =
+        replaceSheet(context.workbook, context.activeSheetIndex, updatedSheet);
+
+    return WorkbookCommandResult(workbook: updatedWorkbook);
+  }
+}

--- a/lib/application/commands/workbook_command.dart
+++ b/lib/application/commands/workbook_command.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/foundation.dart';
+
+import '../../domain/workbook.dart';
+import '../../domain/sheet.dart';
+
+/// Context passed to [WorkbookCommand]s to provide access to the current
+/// workbook and metadata about the selection.
+@immutable
+class WorkbookCommandContext {
+  const WorkbookCommandContext({
+    required this.workbook,
+    required this.activeSheetIndex,
+  });
+
+  final Workbook workbook;
+  final int activeSheetIndex;
+
+  /// Returns the active [Sheet] for the command, or `null` when the index is
+  /// out of range.
+  Sheet? get activeSheet {
+    if (activeSheetIndex < 0 || activeSheetIndex >= workbook.sheets.length) {
+      return null;
+    }
+    return workbook.sheets[activeSheetIndex];
+  }
+
+  bool get hasSheets => workbook.sheets.isNotEmpty;
+}
+
+/// Result returned after executing a [WorkbookCommand].
+@immutable
+class WorkbookCommandResult {
+  const WorkbookCommandResult({
+    required this.workbook,
+    this.activeSheetIndex,
+  });
+
+  final Workbook workbook;
+  final int? activeSheetIndex;
+}
+
+/// Base contract for all commands mutating the [Workbook].
+abstract class WorkbookCommand {
+  const WorkbookCommand();
+
+  /// Human readable label used by ribbon buttons.
+  String get label;
+
+  /// Allows commands to be conditionally enabled.
+  bool canExecute(WorkbookCommandContext context) => true;
+
+  /// Executes the command and returns the resulting workbook state.
+  WorkbookCommandResult execute(WorkbookCommandContext context);
+}

--- a/lib/application/commands/workbook_command_manager.dart
+++ b/lib/application/commands/workbook_command_manager.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/foundation.dart';
+
+import '../../domain/workbook.dart';
+import 'workbook_command.dart';
+
+class WorkbookCommandManager extends ChangeNotifier {
+  WorkbookCommandManager({required Workbook initialWorkbook})
+      : _workbook = initialWorkbook;
+
+  Workbook _workbook;
+  int _activeSheetIndex = 0;
+
+  Workbook get workbook => _workbook;
+  int get activeSheetIndex => _activeSheetIndex;
+
+  WorkbookCommandContext get context => WorkbookCommandContext(
+        workbook: _workbook,
+        activeSheetIndex: _activeSheetIndex,
+      );
+
+  void setActiveSheet(int index) {
+    if (index == _activeSheetIndex) {
+      return;
+    }
+    if (index < 0 || index >= _workbook.sheets.length) {
+      return;
+    }
+    _activeSheetIndex = index;
+    notifyListeners();
+  }
+
+  void execute(WorkbookCommand command) {
+    final commandContext = context;
+    if (!command.canExecute(commandContext)) {
+      return;
+    }
+
+    final result = command.execute(commandContext);
+    var shouldNotify = false;
+    if (!identical(result.workbook, _workbook)) {
+      _workbook = result.workbook;
+      shouldNotify = true;
+    }
+
+    final desiredIndex = result.activeSheetIndex;
+    if (desiredIndex != null && desiredIndex != _activeSheetIndex) {
+      _activeSheetIndex = desiredIndex;
+      shouldNotify = true;
+    } else if (_activeSheetIndex >= _workbook.sheets.length) {
+      _activeSheetIndex = _workbook.sheets.length - 1;
+      shouldNotify = true;
+    }
+
+    if (shouldNotify) {
+      notifyListeners();
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 
+import 'application/commands/workbook_command_manager.dart';
+import 'domain/cell.dart';
+import 'domain/sheet.dart';
+import 'domain/workbook.dart';
 import 'presentation/workbook_navigator.dart';
 
 void main() {
@@ -14,34 +18,36 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  final List<String> _sheets = ['Feuille 1'];
-  int _selectedSheetIndex = 0;
-  int _nextSheetNumber = 2;
+  late final WorkbookCommandManager _commandManager;
 
-  void _handleSelectSheet(int index) {
-    setState(() {
-      _selectedSheetIndex = index;
-    });
+  @override
+  void initState() {
+    super.initState();
+    _commandManager = WorkbookCommandManager(
+      initialWorkbook: _createInitialWorkbook(),
+    );
   }
 
-  void _handleAddSheet() {
-    setState(() {
-      _sheets.add('Feuille $_nextSheetNumber');
-      _nextSheetNumber += 1;
-      _selectedSheetIndex = _sheets.length - 1;
-    });
+  @override
+  void dispose() {
+    _commandManager.dispose();
+    super.dispose();
   }
 
-  void _handleRemoveSheet(int index) {
-    if (_sheets.length == 1) {
-      return;
-    }
-    setState(() {
-      _sheets.removeAt(index);
-      if (_selectedSheetIndex >= _sheets.length) {
-        _selectedSheetIndex = _sheets.length - 1;
-      }
-    });
+  Workbook _createInitialWorkbook() {
+    const rowCount = 20;
+    const columnCount = 8;
+    final rows = List<List<Cell>>.generate(
+      rowCount,
+      (row) => List<Cell>.generate(
+        columnCount,
+        (column) =>
+            Cell(row: row, column: column, type: CellType.empty, value: null),
+      ),
+      growable: false,
+    );
+    final sheet = Sheet(name: 'Feuille 1', rows: rows);
+    return Workbook(sheets: [sheet]);
   }
 
   @override
@@ -57,11 +63,7 @@ class _MyAppState extends State<MyApp> {
           title: const Text('Classeur'),
         ),
         body: WorkbookNavigator(
-          sheets: List.unmodifiable(_sheets),
-          selectedSheetIndex: _selectedSheetIndex,
-          onSheetSelected: _handleSelectSheet,
-          onAddSheet: _handleAddSheet,
-          onRemoveSheet: _handleRemoveSheet,
+          commandManager: _commandManager,
         ),
       ),
     );

--- a/lib/presentation/widgets/command_ribbon.dart
+++ b/lib/presentation/widgets/command_ribbon.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+
+import '../../application/commands/add_sheet_command.dart';
+import '../../application/commands/clear_sheet_command.dart';
+import '../../application/commands/insert_row_command.dart';
+import '../../application/commands/populate_sample_data_command.dart';
+import '../../application/commands/remove_sheet_command.dart';
+import '../../application/commands/uppercase_header_command.dart';
+import '../../application/commands/workbook_command.dart';
+import '../../application/commands/workbook_command_manager.dart';
+
+class CommandRibbon extends StatelessWidget {
+  const CommandRibbon({super.key, required this.commandManager});
+
+  final WorkbookCommandManager commandManager;
+
+  static const List<WorkbookCommand> _editionCommands = <WorkbookCommand>[
+    AddSheetCommand(),
+    InsertRowCommand(),
+    RemoveSheetCommand(),
+  ];
+
+  static const List<WorkbookCommand> _formatCommands = <WorkbookCommand>[
+    UppercaseHeaderCommand(),
+  ];
+
+  static const List<WorkbookCommand> _dataCommands = <WorkbookCommand>[
+    PopulateSampleDataCommand(),
+    ClearSheetCommand(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AnimatedBuilder(
+      animation: commandManager,
+      builder: (context, _) {
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+          child: Material(
+            elevation: 2,
+            color: theme.colorScheme.surface,
+            borderRadius: BorderRadius.circular(16),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Wrap(
+                spacing: 32,
+                runSpacing: 16,
+                children: [
+                  _CommandGroup(
+                    title: 'Édition',
+                    commands: _editionCommands,
+                    manager: commandManager,
+                  ),
+                  _CommandGroup(
+                    title: 'Format',
+                    commands: _formatCommands,
+                    manager: commandManager,
+                  ),
+                  _CommandGroup(
+                    title: 'Données',
+                    commands: _dataCommands,
+                    manager: commandManager,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _CommandGroup extends StatelessWidget {
+  const _CommandGroup({
+    required this.title,
+    required this.commands,
+    required this.manager,
+  });
+
+  final String title;
+  final List<WorkbookCommand> commands;
+  final WorkbookCommandManager manager;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minWidth: 200),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              for (final command in commands)
+                _CommandButton(command: command, manager: manager),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CommandButton extends StatelessWidget {
+  const _CommandButton({required this.command, required this.manager});
+
+  final WorkbookCommand command;
+  final WorkbookCommandManager manager;
+
+  @override
+  Widget build(BuildContext context) {
+    final canExecute = command.canExecute(manager.context);
+    return SizedBox(
+      width: 180,
+      child: FilledButton.tonal(
+        onPressed: canExecute ? () => manager.execute(command) : null,
+        child: Text(
+          command.label,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a command manager and command classes to mutate the workbook model, including sheet management, row insertion, formatting, and data population actions
- wire the UI to the command layer via a new CommandRibbon widget and update the workbook navigator to execute commands for sheet navigation
- synchronise selection state with workbook data so grid and formula bar reflect command-driven updates

## Testing
- flutter analyze *(fails: Flutter tooling is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb5870504832688a459852198ae60