### PR TITLE
Add undo/redo history with reversible workbook commands

### DIFF
--- a/lib/application/commands/add_sheet_command.dart
+++ b/lib/application/commands/add_sheet_command.dart
@@ -4,7 +4,7 @@ import '../../domain/workbook.dart';
 import 'workbook_command.dart';
 
 class AddSheetCommand extends WorkbookCommand {
-  const AddSheetCommand({this.rowCount = 20, this.columnCount = 8});
+  AddSheetCommand({this.rowCount = 20, this.columnCount = 8});
 
   final int rowCount;
   final int columnCount;
@@ -13,7 +13,7 @@ class AddSheetCommand extends WorkbookCommand {
   String get label => 'Nouvelle feuille';
 
   @override
-  WorkbookCommandResult execute(WorkbookCommandContext context) {
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
     final newSheetName = _generateSheetName(context.workbook);
     final rows = List<List<Cell>>.generate(
       rowCount,

--- a/lib/application/commands/clear_sheet_command.dart
+++ b/lib/application/commands/clear_sheet_command.dart
@@ -5,7 +5,7 @@ import 'command_utils.dart';
 import 'workbook_command.dart';
 
 class ClearSheetCommand extends WorkbookCommand {
-  const ClearSheetCommand();
+  ClearSheetCommand();
 
   @override
   String get label => 'Effacer les données';
@@ -17,7 +17,7 @@ class ClearSheetCommand extends WorkbookCommand {
   }
 
   @override
-  WorkbookCommandResult execute(WorkbookCommandContext context) {
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
     final sheet = context.activeSheet;
     if (sheet == null) {
       return WorkbookCommandResult(workbook: context.workbook);

--- a/lib/application/commands/insert_column_command.dart
+++ b/lib/application/commands/insert_column_command.dart
@@ -4,7 +4,7 @@ import 'command_utils.dart';
 import 'workbook_command.dart';
 
 class InsertColumnCommand extends WorkbookCommand {
-  const InsertColumnCommand({this.columnIndex});
+  InsertColumnCommand({this.columnIndex});
 
   final int? columnIndex;
 
@@ -17,7 +17,7 @@ class InsertColumnCommand extends WorkbookCommand {
   }
 
   @override
-  WorkbookCommandResult execute(WorkbookCommandContext context) {
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
     final sheet = context.activeSheet;
     if (sheet == null) {
       return WorkbookCommandResult(workbook: context.workbook);

--- a/lib/application/commands/insert_row_command.dart
+++ b/lib/application/commands/insert_row_command.dart
@@ -4,7 +4,7 @@ import 'command_utils.dart';
 import 'workbook_command.dart';
 
 class InsertRowCommand extends WorkbookCommand {
-  const InsertRowCommand({this.rowIndex});
+  InsertRowCommand({this.rowIndex});
 
   final int? rowIndex;
 
@@ -18,7 +18,7 @@ class InsertRowCommand extends WorkbookCommand {
   }
 
   @override
-  WorkbookCommandResult execute(WorkbookCommandContext context) {
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
     final sheet = context.activeSheet;
     if (sheet == null) {
       return WorkbookCommandResult(workbook: context.workbook);

--- a/lib/application/commands/populate_sample_data_command.dart
+++ b/lib/application/commands/populate_sample_data_command.dart
@@ -5,7 +5,7 @@ import 'command_utils.dart';
 import 'workbook_command.dart';
 
 class PopulateSampleDataCommand extends WorkbookCommand {
-  const PopulateSampleDataCommand();
+  PopulateSampleDataCommand();
 
   @override
   String get label => 'Données d\'exemple';
@@ -17,7 +17,7 @@ class PopulateSampleDataCommand extends WorkbookCommand {
   }
 
   @override
-  WorkbookCommandResult execute(WorkbookCommandContext context) {
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
     final sheet = context.activeSheet;
     if (sheet == null) {
       return WorkbookCommandResult(workbook: context.workbook);

--- a/lib/application/commands/remove_sheet_command.dart
+++ b/lib/application/commands/remove_sheet_command.dart
@@ -2,11 +2,11 @@ import '../../domain/workbook.dart';
 import 'workbook_command.dart';
 
 class RemoveSheetCommand extends WorkbookCommand {
-  const RemoveSheetCommand({this.sheetIndex});
+  RemoveSheetCommand({this.sheetIndex});
 
   final int? sheetIndex;
 
-  const RemoveSheetCommand.forIndex(int index) : sheetIndex = index;
+  RemoveSheetCommand.forIndex(int index) : sheetIndex = index;
 
   @override
   String get label => 'Supprimer la feuille';
@@ -20,7 +20,7 @@ class RemoveSheetCommand extends WorkbookCommand {
   }
 
   @override
-  WorkbookCommandResult execute(WorkbookCommandContext context) {
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
     final index = sheetIndex ?? context.activeSheetIndex;
     if (!canExecute(context)) {
       return WorkbookCommandResult(workbook: context.workbook);

--- a/lib/application/commands/uppercase_header_command.dart
+++ b/lib/application/commands/uppercase_header_command.dart
@@ -5,7 +5,7 @@ import 'command_utils.dart';
 import 'workbook_command.dart';
 
 class UppercaseHeaderCommand extends WorkbookCommand {
-  const UppercaseHeaderCommand();
+  UppercaseHeaderCommand();
 
   @override
   String get label => 'Entêtes en majuscules';
@@ -17,7 +17,7 @@ class UppercaseHeaderCommand extends WorkbookCommand {
   }
 
   @override
-  WorkbookCommandResult execute(WorkbookCommandContext context) {
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
     final sheet = context.activeSheet;
     if (sheet == null || sheet.rowCount == 0) {
       return WorkbookCommandResult(workbook: context.workbook);

--- a/lib/application/commands/workbook_command.dart
+++ b/lib/application/commands/workbook_command.dart
@@ -41,7 +41,7 @@ class WorkbookCommandResult {
 
 /// Base contract for all commands mutating the [Workbook].
 abstract class WorkbookCommand {
-  const WorkbookCommand();
+  WorkbookCommand();
 
   /// Human readable label used by ribbon buttons.
   String get label;
@@ -50,5 +50,26 @@ abstract class WorkbookCommand {
   bool canExecute(WorkbookCommandContext context) => true;
 
   /// Executes the command and returns the resulting workbook state.
-  WorkbookCommandResult execute(WorkbookCommandContext context);
+  WorkbookCommandResult execute(WorkbookCommandContext context) {
+    _previousState = WorkbookCommandResult(
+      workbook: context.workbook,
+      activeSheetIndex: context.activeSheetIndex,
+    );
+    return performExecute(context);
+  }
+
+  /// Performs the actual mutation for the command.
+  @protected
+  WorkbookCommandResult performExecute(WorkbookCommandContext context);
+
+  /// Reverts the command to its previous state.
+  WorkbookCommandResult unexecute() {
+    final previous = _previousState;
+    if (previous == null) {
+      throw StateError('Cannot unexecute a command that was never executed.');
+    }
+    return previous;
+  }
+
+  WorkbookCommandResult? _previousState;
 }

--- a/lib/presentation/widgets/command_ribbon.dart
+++ b/lib/presentation/widgets/command_ribbon.dart
@@ -10,25 +10,30 @@ import '../../application/commands/uppercase_header_command.dart';
 import '../../application/commands/workbook_command.dart';
 import '../../application/commands/workbook_command_manager.dart';
 
+typedef WorkbookCommandBuilder = WorkbookCommand Function();
+
 class CommandRibbon extends StatelessWidget {
   const CommandRibbon({super.key, required this.commandManager});
 
   final WorkbookCommandManager commandManager;
 
-  static const List<WorkbookCommand> _editionCommands = <WorkbookCommand>[
-    AddSheetCommand(),
-    InsertRowCommand(),
-    InsertColumnCommand(),
-    RemoveSheetCommand(),
+  static final List<WorkbookCommandBuilder> _editionCommands =
+      <WorkbookCommandBuilder>[
+    () => AddSheetCommand(),
+    () => InsertRowCommand(),
+    () => InsertColumnCommand(),
+    () => RemoveSheetCommand(),
   ];
 
-  static const List<WorkbookCommand> _formatCommands = <WorkbookCommand>[
-    UppercaseHeaderCommand(),
+  static final List<WorkbookCommandBuilder> _formatCommands =
+      <WorkbookCommandBuilder>[
+    () => UppercaseHeaderCommand(),
   ];
 
-  static const List<WorkbookCommand> _dataCommands = <WorkbookCommand>[
-    PopulateSampleDataCommand(),
-    ClearSheetCommand(),
+  static final List<WorkbookCommandBuilder> _dataCommands =
+      <WorkbookCommandBuilder>[
+    () => PopulateSampleDataCommand(),
+    () => ClearSheetCommand(),
   ];
 
   @override
@@ -49,6 +54,7 @@ class CommandRibbon extends StatelessWidget {
                 spacing: 32,
                 runSpacing: 16,
                 children: [
+                  _HistoryGroup(manager: commandManager),
                   _CommandGroup(
                     title: 'Édition',
                     commands: _editionCommands,
@@ -82,7 +88,7 @@ class _CommandGroup extends StatelessWidget {
   });
 
   final String title;
-  final List<WorkbookCommand> commands;
+  final List<WorkbookCommandBuilder> commands;
   final WorkbookCommandManager manager;
 
   @override
@@ -102,8 +108,8 @@ class _CommandGroup extends StatelessWidget {
             spacing: 12,
             runSpacing: 12,
             children: [
-              for (final command in commands)
-                _CommandButton(command: command, manager: manager),
+              for (final builder in commands)
+                _CommandButton(builder: builder, manager: manager),
             ],
           ),
         ],
@@ -113,20 +119,87 @@ class _CommandGroup extends StatelessWidget {
 }
 
 class _CommandButton extends StatelessWidget {
-  const _CommandButton({required this.command, required this.manager});
+  const _CommandButton({required this.builder, required this.manager});
 
-  final WorkbookCommand command;
+  final WorkbookCommandBuilder builder;
   final WorkbookCommandManager manager;
 
   @override
   Widget build(BuildContext context) {
-    final canExecute = command.canExecute(manager.context);
+    final prototype = builder();
+    final canExecute = prototype.canExecute(manager.context);
     return SizedBox(
       width: 180,
       child: FilledButton.tonal(
-        onPressed: canExecute ? () => manager.execute(command) : null,
+        onPressed: canExecute ? () => manager.execute(builder()) : null,
         child: Text(
-          command.label,
+          prototype.label,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}
+
+class _HistoryGroup extends StatelessWidget {
+  const _HistoryGroup({required this.manager});
+
+  final WorkbookCommandManager manager;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minWidth: 200),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Historique',
+            style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              _HistoryButton(
+                label: 'Annuler',
+                isEnabled: manager.canUndo,
+                onPressed: manager.undo,
+              ),
+              _HistoryButton(
+                label: 'Rétablir',
+                isEnabled: manager.canRedo,
+                onPressed: manager.redo,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HistoryButton extends StatelessWidget {
+  const _HistoryButton({
+    required this.label,
+    required this.isEnabled,
+    required this.onPressed,
+  });
+
+  final String label;
+  final bool isEnabled;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 180,
+      child: FilledButton.tonal(
+        onPressed: isEnabled ? onPressed : null,
+        child: Text(
+          label,
           textAlign: TextAlign.center,
         ),
       ),

--- a/lib/presentation/workbook_navigator.dart
+++ b/lib/presentation/workbook_navigator.dart
@@ -129,7 +129,7 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator> {
     if (_currentPageIndex >= 0 && _currentPageIndex < workbook.sheets.length) {
       _commitEditsForSheet(workbook.sheets[_currentPageIndex].name);
     }
-    _manager.execute(const AddSheetCommand());
+    _manager.execute(AddSheetCommand());
   }
 
   void _handleRemoveSheet(int index) {

--- a/lib/services/history_service.dart
+++ b/lib/services/history_service.dart
@@ -1,0 +1,56 @@
+import 'package:meta/meta.dart';
+
+/// Maintains an undo/redo history for command objects.
+class HistoryService<TCommand> {
+  HistoryService();
+
+  final List<TCommand> _executedCommands = <TCommand>[];
+  final List<TCommand> _undoneCommands = <TCommand>[];
+
+  /// Clears both the executed and undone command stacks.
+  @visibleForTesting
+  void clear() {
+    _executedCommands.clear();
+    _undoneCommands.clear();
+  }
+
+  /// Records a freshly executed [command].
+  void pushExecuted(TCommand command) {
+    _executedCommands.add(command);
+    _undoneCommands.clear();
+  }
+
+  /// Pops the last executed command for undoing.
+  TCommand? popUndo() {
+    if (_executedCommands.isEmpty) {
+      return null;
+    }
+    final command = _executedCommands.removeLast();
+    _undoneCommands.add(command);
+    return command;
+  }
+
+  /// Pops the last undone command for re-execution.
+  TCommand? popRedo() {
+    if (_undoneCommands.isEmpty) {
+      return null;
+    }
+    final command = _undoneCommands.removeLast();
+    _executedCommands.add(command);
+    return command;
+  }
+
+  /// Whether an undo operation can be performed.
+  bool get canUndo => _executedCommands.isNotEmpty;
+
+  /// Whether a redo operation can be performed.
+  bool get canRedo => _undoneCommands.isNotEmpty;
+
+  @visibleForTesting
+  List<TCommand> get executedCommands =>
+      List<TCommand>.unmodifiable(_executedCommands);
+
+  @visibleForTesting
+  List<TCommand> get undoneCommands =>
+      List<TCommand>.unmodifiable(_undoneCommands);
+}

--- a/test/services/history_service_test.dart
+++ b/test/services/history_service_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_application_1/application/commands/workbook_command.dart';
+import 'package:flutter_application_1/application/commands/workbook_command_manager.dart';
+import 'package:flutter_application_1/domain/sheet.dart';
+import 'package:flutter_application_1/domain/workbook.dart';
+import 'package:flutter_application_1/services/history_service.dart';
+
+void main() {
+  group('HistoryService', () {
+    test('records executed commands and exposes undo/redo stacks', () {
+      final history = HistoryService<String>();
+
+      expect(history.canUndo, isFalse);
+      expect(history.canRedo, isFalse);
+
+      history.pushExecuted('cmd1');
+      history.pushExecuted('cmd2');
+
+      expect(history.executedCommands, equals(['cmd1', 'cmd2']));
+      expect(history.undoneCommands, isEmpty);
+      expect(history.canUndo, isTrue);
+      expect(history.canRedo, isFalse);
+
+      final undo = history.popUndo();
+      expect(undo, 'cmd2');
+      expect(history.executedCommands, equals(['cmd1']));
+      expect(history.undoneCommands, equals(['cmd2']));
+      expect(history.canRedo, isTrue);
+
+      final redo = history.popRedo();
+      expect(redo, 'cmd2');
+      expect(history.executedCommands, equals(['cmd1', 'cmd2']));
+      expect(history.undoneCommands, isEmpty);
+      expect(history.canRedo, isFalse);
+    });
+  });
+
+  group('WorkbookCommandManager undo/redo', () {
+    late Workbook initialWorkbook;
+    late Workbook updatedWorkbook;
+    late HistoryService<WorkbookCommand> history;
+
+    setUp(() {
+      initialWorkbook = _buildWorkbook('Initial');
+      updatedWorkbook = _buildWorkbook('Updated');
+      history = HistoryService<WorkbookCommand>();
+    });
+
+    test('execute records command and undo restores previous workbook', () {
+      final manager = WorkbookCommandManager(
+        initialWorkbook: initialWorkbook,
+        historyService: history,
+      );
+      final command = _ReplaceWorkbookCommand(updatedWorkbook);
+
+      final changed = manager.execute(command);
+      expect(changed, isTrue);
+      expect(manager.workbook, same(updatedWorkbook));
+      expect(manager.canUndo, isTrue);
+      expect(manager.canRedo, isFalse);
+
+      manager.undo();
+      expect(manager.workbook, same(initialWorkbook));
+      expect(manager.canUndo, isFalse);
+      expect(manager.canRedo, isTrue);
+
+      manager.redo();
+      expect(manager.workbook, same(updatedWorkbook));
+      expect(manager.canUndo, isTrue);
+      expect(manager.canRedo, isFalse);
+    });
+  });
+}
+
+Workbook _buildWorkbook(String value) {
+  final sheet = Sheet.fromRows(
+    name: 'Sheet 1',
+    rows: [
+      [value],
+    ],
+  );
+  return Workbook(sheets: [sheet]);
+}
+
+class _ReplaceWorkbookCommand extends WorkbookCommand {
+  _ReplaceWorkbookCommand(this._replacement);
+
+  final Workbook _replacement;
+
+  @override
+  String get label => 'Replace workbook';
+
+  @override
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
+    return WorkbookCommandResult(workbook: _replacement);
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `HistoryService` to track executed commands and their redo stack
- capture previous state inside workbook commands and teach the command manager to undo/redo via the history service
- surface Undo/Redo buttons in the command ribbon and cover the new history behaviour with unit tests

## Testing
- flutter test *(fails: `flutter` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc56ff2bc8326912daddbfef0cc7f