### PR TITLE
Refactor workbook commands for page support

### DIFF
--- a/lib/application/commands/add_menu_page_command.dart
+++ b/lib/application/commands/add_menu_page_command.dart
@@ -1,0 +1,49 @@
+import '../../domain/menu_page.dart';
+import '../../domain/workbook.dart';
+import 'workbook_command.dart';
+
+class AddMenuPageCommand extends WorkbookCommand {
+  AddMenuPageCommand({
+    this.layout = 'list',
+    Map<String, Object?> metadata = const {},
+  }) : metadata = Map<String, Object?>.unmodifiable(metadata);
+
+  final String layout;
+  final Map<String, Object?> metadata;
+
+  @override
+  String get label => 'Nouvelle page menu';
+
+  @override
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
+    final newPageName = _generatePageName(context.workbook);
+    final newPage = MenuPage(
+      name: newPageName,
+      layout: layout,
+      metadata: metadata,
+    );
+    final pages = context.workbook.pages.toList(growable: true)..add(newPage);
+    final updatedWorkbook = Workbook(pages: pages);
+    final newIndex = updatedWorkbook.pages.indexOf(newPage);
+    assert(newIndex != -1, 'Newly added menu page must be present in workbook.');
+
+    return WorkbookCommandResult(
+      workbook: updatedWorkbook,
+      activePageIndex: newIndex,
+    );
+  }
+
+  String _generatePageName(Workbook workbook) {
+    const prefix = 'Menu ';
+    var highest = 0;
+    for (final page in workbook.pages.whereType<MenuPage>()) {
+      if (page.name.startsWith(prefix)) {
+        final maybeNumber = int.tryParse(page.name.substring(prefix.length));
+        if (maybeNumber != null && maybeNumber > highest) {
+          highest = maybeNumber;
+        }
+      }
+    }
+    return '$prefix${highest + 1}';
+  }
+}

--- a/lib/application/commands/add_sheet_command.dart
+++ b/lib/application/commands/add_sheet_command.dart
@@ -28,12 +28,12 @@ class AddSheetCommand extends WorkbookCommand {
     final newSheet = Sheet(name: newSheetName, rows: rows);
     final pages = context.workbook.pages.toList(growable: true)..add(newSheet);
     final updatedWorkbook = Workbook(pages: pages);
-    final newIndex = updatedWorkbook.sheets.indexOf(newSheet);
+    final newIndex = updatedWorkbook.pages.indexOf(newSheet);
     assert(newIndex != -1, 'Newly added sheet must be present in workbook.');
 
     return WorkbookCommandResult(
       workbook: updatedWorkbook,
-      activeSheetIndex: newIndex,
+      activePageIndex: newIndex,
     );
   }
 

--- a/lib/application/commands/clear_sheet_command.dart
+++ b/lib/application/commands/clear_sheet_command.dart
@@ -23,6 +23,11 @@ class ClearSheetCommand extends WorkbookCommand {
       return WorkbookCommandResult(workbook: context.workbook);
     }
 
+    final pageIndex = context.pageIndexOf(sheet);
+    if (pageIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
     final rows = cloneSheetRows(sheet);
     for (var r = 0; r < rows.length; r++) {
       final row = rows[r];
@@ -33,8 +38,11 @@ class ClearSheetCommand extends WorkbookCommand {
 
     final updatedSheet = rebuildSheetFromRows(sheet, rows);
     final Workbook updatedWorkbook =
-        replaceSheet(context.workbook, context.activeSheetIndex, updatedSheet);
+        replaceSheetAtPageIndex(context.workbook, pageIndex, updatedSheet);
 
-    return WorkbookCommandResult(workbook: updatedWorkbook);
+    return WorkbookCommandResult(
+      workbook: updatedWorkbook,
+      activePageIndex: context.activePageIndex,
+    );
   }
 }

--- a/lib/application/commands/command_utils.dart
+++ b/lib/application/commands/command_utils.dart
@@ -1,6 +1,7 @@
 import '../../domain/cell.dart';
 import '../../domain/sheet.dart';
 import '../../domain/workbook.dart';
+import '../../domain/workbook_page.dart';
 
 List<List<Cell>> cloneSheetRows(Sheet sheet) {
   final sourceRows = sheet.rows;
@@ -38,13 +39,29 @@ List<List<Cell>> normaliseCellCoordinates(List<List<Cell>> rows) {
   }
   return rows;
 }
-Workbook replaceSheet(Workbook workbook, int sheetIndex, Sheet newSheet) {
-  final target = workbook.sheets[sheetIndex];
+Workbook replacePage(
+  Workbook workbook,
+  int pageIndex,
+  WorkbookPage newPage,
+) {
+  if (pageIndex < 0 || pageIndex >= workbook.pages.length) {
+    throw RangeError.index(pageIndex, workbook.pages, 'pageIndex');
+  }
   final pages = workbook.pages.toList(growable: true);
-  final pageIndex = pages.indexOf(target);
-  assert(pageIndex != -1, 'Sheet must exist in workbook pages.');
-  pages[pageIndex] = newSheet;
+  pages[pageIndex] = newPage;
   return Workbook(pages: pages);
+}
+
+Workbook replaceSheetAtPageIndex(
+  Workbook workbook,
+  int pageIndex,
+  Sheet newSheet,
+) {
+  final page = workbook.pages[pageIndex];
+  if (page is! Sheet) {
+    throw StateError('The page at index $pageIndex is not a Sheet.');
+  }
+  return replacePage(workbook, pageIndex, newSheet);
 }
 
 Sheet rebuildSheetFromRows(Sheet template, List<List<Cell>> rows) {

--- a/lib/application/commands/insert_column_command.dart
+++ b/lib/application/commands/insert_column_command.dart
@@ -23,6 +23,11 @@ class InsertColumnCommand extends WorkbookCommand {
       return WorkbookCommandResult(workbook: context.workbook);
     }
 
+    final pageIndex = context.pageIndexOf(sheet);
+    if (pageIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
     final rows = cloneSheetRows(sheet);
     final existingColumnCount = sheet.columnCount;
     final desiredIndex = columnIndex ?? existingColumnCount;
@@ -43,8 +48,11 @@ class InsertColumnCommand extends WorkbookCommand {
     final normalisedRows = normaliseCellCoordinates(rows);
     final updatedSheet = rebuildSheetFromRows(sheet, normalisedRows);
     final Workbook updatedWorkbook =
-        replaceSheet(context.workbook, context.activeSheetIndex, updatedSheet);
+        replaceSheetAtPageIndex(context.workbook, pageIndex, updatedSheet);
 
-    return WorkbookCommandResult(workbook: updatedWorkbook);
+    return WorkbookCommandResult(
+      workbook: updatedWorkbook,
+      activePageIndex: context.activePageIndex,
+    );
   }
 }

--- a/lib/application/commands/insert_row_command.dart
+++ b/lib/application/commands/insert_row_command.dart
@@ -24,6 +24,11 @@ class InsertRowCommand extends WorkbookCommand {
       return WorkbookCommandResult(workbook: context.workbook);
     }
 
+    final pageIndex = context.pageIndexOf(sheet);
+    if (pageIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
     final rows = cloneSheetRows(sheet);
     final desiredIndex = rowIndex ?? rows.length;
     final insertIndex = desiredIndex < 0
@@ -37,8 +42,11 @@ class InsertRowCommand extends WorkbookCommand {
 
     final updatedSheet = rebuildSheetFromRows(sheet, normalisedRows);
     final Workbook updatedWorkbook =
-        replaceSheet(context.workbook, context.activeSheetIndex, updatedSheet);
+        replaceSheetAtPageIndex(context.workbook, pageIndex, updatedSheet);
 
-    return WorkbookCommandResult(workbook: updatedWorkbook);
+    return WorkbookCommandResult(
+      workbook: updatedWorkbook,
+      activePageIndex: context.activePageIndex,
+    );
   }
 }

--- a/lib/application/commands/populate_sample_data_command.dart
+++ b/lib/application/commands/populate_sample_data_command.dart
@@ -23,6 +23,11 @@ class PopulateSampleDataCommand extends WorkbookCommand {
       return WorkbookCommandResult(workbook: context.workbook);
     }
 
+    final pageIndex = context.pageIndexOf(sheet);
+    if (pageIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
     const sample = <List<Object?>>[
       ['Nom', 'Âge', 'Ville', 'Profession'],
       ['Alice', 29, 'Paris', 'Designer'],
@@ -48,8 +53,11 @@ class PopulateSampleDataCommand extends WorkbookCommand {
 
     final updatedSheet = rebuildSheetFromRows(sheet, rows);
     final Workbook updatedWorkbook =
-        replaceSheet(context.workbook, context.activeSheetIndex, updatedSheet);
+        replaceSheetAtPageIndex(context.workbook, pageIndex, updatedSheet);
 
-    return WorkbookCommandResult(workbook: updatedWorkbook);
+    return WorkbookCommandResult(
+      workbook: updatedWorkbook,
+      activePageIndex: context.activePageIndex,
+    );
   }
 }

--- a/lib/application/commands/remove_sheet_command.dart
+++ b/lib/application/commands/remove_sheet_command.dart
@@ -13,31 +13,38 @@ class RemoveSheetCommand extends WorkbookCommand {
 
   @override
   bool canExecute(WorkbookCommandContext context) {
+    if (context.workbook.pages.length <= 1) {
+      return false;
+    }
     final index = sheetIndex ?? context.activeSheetIndex;
-    return context.workbook.sheets.length > 1 &&
+    return index != null &&
         index >= 0 &&
         index < context.workbook.sheets.length;
   }
 
   @override
   WorkbookCommandResult performExecute(WorkbookCommandContext context) {
-    final index = sheetIndex ?? context.activeSheetIndex;
+    final tabIndex = sheetIndex ?? context.activeSheetIndex;
+    if (tabIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
     if (!canExecute(context)) {
       return WorkbookCommandResult(workbook: context.workbook);
     }
 
-    final sheet = context.workbook.sheets[index];
+    final sheet = context.workbook.sheets[tabIndex];
     final pages = context.workbook.pages.toList(growable: true);
     final pageIndex = pages.indexOf(sheet);
     assert(pageIndex != -1, 'Sheet must exist in workbook pages.');
     pages.removeAt(pageIndex);
     final updatedWorkbook = Workbook(pages: pages);
 
-    final newActiveIndex = index.clamp(0, updatedWorkbook.sheets.length - 1);
+    final maxIndex = updatedWorkbook.pages.length - 1;
+    final newActiveIndex = pageIndex > maxIndex ? maxIndex : pageIndex;
 
     return WorkbookCommandResult(
       workbook: updatedWorkbook,
-      activeSheetIndex: newActiveIndex,
+      activePageIndex: newActiveIndex,
     );
   }
 }

--- a/lib/application/commands/set_page_layout_command.dart
+++ b/lib/application/commands/set_page_layout_command.dart
@@ -1,0 +1,63 @@
+import '../../domain/menu_page.dart';
+import 'command_utils.dart';
+import 'workbook_command.dart';
+
+class SetPageLayoutCommand extends WorkbookCommand {
+  SetPageLayoutCommand({
+    required this.layout,
+    this.pageIndex,
+  });
+
+  final String layout;
+  final int? pageIndex;
+
+  @override
+  String get label => 'Définir la mise en page';
+
+  int? _resolvePageIndex(WorkbookCommandContext context) {
+    if (pageIndex != null) {
+      if (pageIndex! < 0 || pageIndex! >= context.workbook.pages.length) {
+        return null;
+      }
+      return pageIndex;
+    }
+    if (!context.hasPages) {
+      return null;
+    }
+    return context.activePageIndex;
+  }
+
+  @override
+  bool canExecute(WorkbookCommandContext context) {
+    final targetIndex = _resolvePageIndex(context);
+    if (targetIndex == null) {
+      return false;
+    }
+    final page = context.workbook.pages[targetIndex];
+    return page is MenuPage;
+  }
+
+  @override
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
+    final targetIndex = _resolvePageIndex(context);
+    if (targetIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+    final page = context.workbook.pages[targetIndex];
+    if (page is! MenuPage) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    final updatedPage = page.copyWith(layout: layout);
+    final updatedWorkbook = replacePage(
+      context.workbook,
+      targetIndex,
+      updatedPage,
+    );
+
+    return WorkbookCommandResult(
+      workbook: updatedWorkbook,
+      activePageIndex: context.activePageIndex,
+    );
+  }
+}

--- a/lib/application/commands/uppercase_header_command.dart
+++ b/lib/application/commands/uppercase_header_command.dart
@@ -23,6 +23,11 @@ class UppercaseHeaderCommand extends WorkbookCommand {
       return WorkbookCommandResult(workbook: context.workbook);
     }
 
+    final pageIndex = context.pageIndexOf(sheet);
+    if (pageIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
     final rows = cloneSheetRows(sheet);
     final headerRow = rows.first;
     for (var c = 0; c < headerRow.length; c++) {
@@ -39,8 +44,11 @@ class UppercaseHeaderCommand extends WorkbookCommand {
 
     final updatedSheet = rebuildSheetFromRows(sheet, rows);
     final Workbook updatedWorkbook =
-        replaceSheet(context.workbook, context.activeSheetIndex, updatedSheet);
+        replaceSheetAtPageIndex(context.workbook, pageIndex, updatedSheet);
 
-    return WorkbookCommandResult(workbook: updatedWorkbook);
+    return WorkbookCommandResult(
+      workbook: updatedWorkbook,
+      activePageIndex: context.activePageIndex,
+    );
   }
 }

--- a/lib/domain/menu_page.dart
+++ b/lib/domain/menu_page.dart
@@ -1,0 +1,51 @@
+import 'package:meta/meta.dart';
+
+import 'workbook_page.dart';
+
+/// Represents a navigational menu page in the workbook.
+@immutable
+class MenuPage extends WorkbookPage {
+  MenuPage({
+    required this.name,
+    String layout = 'list',
+    Map<String, Object?> metadata = const {},
+  })  : assert(name.isNotEmpty, 'Menu pages must be named.'),
+        _metadata = Map<String, Object?>.unmodifiable({
+          ...metadata,
+          'layout': layout,
+        });
+
+  @override
+  final String name;
+
+  @override
+  String get type => 'menu';
+
+  final Map<String, Object?> _metadata;
+
+  @override
+  Map<String, Object?> get metadata => _metadata;
+
+  /// Current layout identifier stored in the metadata.
+  String get layout => metadata['layout'] as String? ?? 'list';
+
+  /// Returns a copy of the page with the provided metadata overrides.
+  MenuPage copyWith({
+    String? name,
+    String? layout,
+    Map<String, Object?>? metadata,
+  }) {
+    final nextMetadata = Map<String, Object?>.from(_metadata);
+    if (metadata != null) {
+      nextMetadata.addAll(metadata);
+    }
+    if (layout != null) {
+      nextMetadata['layout'] = layout;
+    }
+    return MenuPage(
+      name: name ?? this.name,
+      layout: nextMetadata['layout'] as String? ?? 'list',
+      metadata: nextMetadata,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extend the workbook command context/manager so commands address workbook pages instead of only sheets
- adjust existing sheet commands and helpers to work with page indices and preserve selection state
- add a MenuPage model plus commands for creating menu pages and updating their layout while keeping the navigator resilient to non-sheet pages

## Testing
- not run (flutter tool unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd3f8556cc832684524bea6d88a183