### PR TITLE
Add YAML code editor to admin panel

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   meta: ^1.16.0
   path_provider: ^2.1.4
   yaml: ^3.1.2
+  code_text_field: ^1.1.0
+  highlight: ^0.8.3
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add the code_text_field and highlight dependencies for the script editor
- replace the admin panel TextField with a YAML-aware CodeField that supports line numbers and theming
- keep the script editor controller wiring so changes continue to propagate through the page

## Testing
- `flutter pub get` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df1e98dd9c832681e735575061df03