### PR TITLE
Downgrade highlight dependency version

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -91,6 +91,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  highlight:
+    dependency: "direct main"
+    description:
+      name: highlight
+      sha256: "5353a83ffe3e3eca7df0abfb72dcf3fa66cc56b953728e7113ad4ad88497cf21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   path_provider: ^2.1.4
   yaml: ^3.1.2
   code_text_field: ^1.1.0
-  highlight: ^0.8.3
+  highlight: ^0.7.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- downgrade the `highlight` dependency to `^0.7.0`
- refresh the lockfile entry to pin `highlight` 0.7.0 with its checksum

## Testing
- flutter pub get *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68df25ac6f3883269253e80c8f79e1fc