### PR TITLE
Remove explicit vsync from workbook navigator animation

### DIFF
--- a/lib/presentation/workbook_navigator.dart
+++ b/lib/presentation/workbook_navigator.dart
@@ -58,8 +58,7 @@ class WorkbookNavigator extends StatefulWidget {
   State<WorkbookNavigator> createState() => _WorkbookNavigatorState();
 }
 
-class _WorkbookNavigatorState extends State<WorkbookNavigator>
-    with TickerProviderStateMixin {
+class _WorkbookNavigatorState extends State<WorkbookNavigator> {
   late PageController _pageController;
   final Map<String, SheetSelectionState> _selectionStates =
       <String, SheetSelectionState>{};
@@ -1154,7 +1153,6 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator>
           duration: const Duration(milliseconds: 200),
           curve: Curves.easeInOut,
           alignment: Alignment.topCenter,
-          vsync: this,
           child: SizedBox(
             width: constraints.maxWidth,
             height: constraints.maxHeight,


### PR DESCRIPTION
## Summary
- remove the unused TickerProviderStateMixin from `_WorkbookNavigatorState`
- let the script editor `AnimatedSize` widget manage its own ticker

## Testing
- flutter build apk *(fails: Flutter SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdcbd73f88326a95ad79deee531bb