### PR TITLE
Fix script cache key per descriptor

### DIFF
--- a/lib/application/scripts/runtime.dart
+++ b/lib/application/scripts/runtime.dart
@@ -554,7 +554,8 @@ class ScriptRuntime {
     return ScriptDescriptor(scope: ScriptScope.page, key: _pageKeyFor(page));
   }
 
-  String _cacheKey(ScriptDescriptor descriptor) => ':';
+  String _cacheKey(ScriptDescriptor descriptor) =>
+      '${descriptor.scope.name}:${descriptor.key}';
 }
 
 class _ExecutionScope {


### PR DESCRIPTION
## Summary
- return a unique cache key for each script descriptor to avoid collisions when loading scripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01ea9c1788326a4615de84f23e56c