### PR TITLE
Align script editor text to top

### DIFF
--- a/lib/presentation/workbook_navigator.dart
+++ b/lib/presentation/workbook_navigator.dart
@@ -1220,6 +1220,7 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator> {
                 child: CodeField(
                   controller: _scriptEditorController,
                   expands: true,
+                  textAlignVertical: TextAlignVertical.top,
                   textStyle: const TextStyle(
                     fontFamily: 'monospace',
                     fontSize: 13,


### PR DESCRIPTION
## Summary
- ensure the script editor CodeField keeps its content anchored to the top by specifying a top vertical alignment

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e021ac415883268d70c82a7ef12038