### PR TITLE
Default top alignment in script editor

### DIFF
--- a/lib/presentation/widgets/top_aligned_code_field.dart
+++ b/lib/presentation/widgets/top_aligned_code_field.dart
@@ -1,0 +1,295 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:code_text_field/code_text_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:linked_scroll_controller/linked_scroll_controller.dart';
+
+/// A local copy of [CodeField] that exposes [textAlignVertical] so we can
+/// ensure the editable content stays anchored to the top of the editor.
+class TopAlignedCodeField extends StatefulWidget {
+  const TopAlignedCodeField({
+    super.key,
+    required this.controller,
+    this.minLines,
+    this.maxLines,
+    this.expands = false,
+    this.wrap = false,
+    this.background,
+    this.decoration,
+    this.textStyle,
+    this.padding = EdgeInsets.zero,
+    this.lineNumberStyle = const LineNumberStyle(),
+    this.enabled,
+    this.onTap,
+    this.readOnly = false,
+    this.cursorColor,
+    this.textSelectionTheme,
+    this.lineNumberBuilder,
+    this.focusNode,
+    this.onChanged,
+    this.isDense = false,
+    this.smartQuotesType,
+    this.keyboardType,
+    this.lineNumbers = true,
+    this.horizontalScroll = true,
+    this.selectionControls,
+    this.textAlignVertical = TextAlignVertical.top,
+  });
+
+  final SmartQuotesType? smartQuotesType;
+  final TextInputType? keyboardType;
+  final int? minLines;
+  final int? maxLines;
+  final bool expands;
+  final bool wrap;
+  final CodeController controller;
+  final LineNumberStyle lineNumberStyle;
+  final Color? cursorColor;
+  final TextStyle? textStyle;
+  final TextSpan Function(int, TextStyle?)? lineNumberBuilder;
+  final bool? enabled;
+  final void Function(String)? onChanged;
+  final bool readOnly;
+  final bool isDense;
+  final TextSelectionControls? selectionControls;
+  final Color? background;
+  final EdgeInsets padding;
+  final Decoration? decoration;
+  final TextSelectionThemeData? textSelectionTheme;
+  final FocusNode? focusNode;
+  final void Function()? onTap;
+  final bool lineNumbers;
+  final bool horizontalScroll;
+  final TextAlignVertical textAlignVertical;
+
+  @override
+  State<TopAlignedCodeField> createState() => _TopAlignedCodeFieldState();
+}
+
+class _TopAlignedCodeFieldState extends State<TopAlignedCodeField> {
+  LinkedScrollControllerGroup? _controllers;
+  ScrollController? _numberScroll;
+  ScrollController? _codeScroll;
+  LineNumberController? _numberController;
+
+  StreamSubscription<bool>? _keyboardVisibilitySubscription;
+  FocusNode? _focusNode;
+  String? lines;
+  String longestLine = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _controllers = LinkedScrollControllerGroup();
+    _numberScroll = _controllers?.addAndGet();
+    _codeScroll = _controllers?.addAndGet();
+    _numberController = LineNumberController(widget.lineNumberBuilder);
+    widget.controller.addListener(_onTextChanged);
+    _focusNode = widget.focusNode ?? FocusNode();
+    _focusNode!.onKey = _onKey;
+    _focusNode!.attach(context, onKey: _onKey);
+
+    _onTextChanged();
+  }
+
+  KeyEventResult _onKey(FocusNode node, RawKeyEvent event) {
+    if (widget.readOnly) {
+      return KeyEventResult.ignored;
+    }
+
+    return widget.controller.onKey(event);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onTextChanged);
+    _numberScroll?.dispose();
+    _codeScroll?.dispose();
+    _numberController?.dispose();
+    _keyboardVisibilitySubscription?.cancel();
+    super.dispose();
+  }
+
+  void _onTextChanged() {
+    final str = widget.controller.text.split('\n');
+    final buf = <String>[];
+
+    for (var k = 0; k < str.length; k++) {
+      buf.add((k + 1).toString());
+    }
+
+    _numberController?.text = buf.join('\n');
+
+    longestLine = '';
+    for (final line in widget.controller.text.split('\n')) {
+      if (line.length > longestLine.length) {
+        longestLine = line;
+      }
+    }
+
+    setState(() {});
+  }
+
+  Widget _wrapInScrollView(
+    Widget codeField,
+    TextStyle textStyle,
+    double minWidth,
+  ) {
+    final leftPad = widget.lineNumberStyle.margin / 2;
+    final intrinsic = IntrinsicWidth(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxHeight: 0,
+              minWidth: max(minWidth - leftPad, 0),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.only(right: 16),
+              child: Text(longestLine, style: textStyle),
+            ),
+          ),
+          widget.expands ? Expanded(child: codeField) : codeField,
+        ],
+      ),
+    );
+
+    return SingleChildScrollView(
+      padding: EdgeInsets.only(
+        left: leftPad,
+        right: widget.padding.right,
+      ),
+      scrollDirection: Axis.horizontal,
+      physics:
+          widget.horizontalScroll ? null : const NeverScrollableScrollPhysics(),
+      child: intrinsic,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const rootKey = 'root';
+    final defaultBg = Colors.grey.shade900;
+    final defaultText = Colors.grey.shade200;
+
+    final styles = CodeTheme.of(context)?.styles;
+    Color? backgroundCol =
+        widget.background ?? styles?[rootKey]?.backgroundColor ?? defaultBg;
+
+    if (widget.decoration != null) {
+      backgroundCol = null;
+    }
+
+    TextStyle textStyle = widget.textStyle ?? const TextStyle();
+    textStyle = textStyle.copyWith(
+      color: textStyle.color ?? styles?[rootKey]?.color ?? defaultText,
+      fontSize: textStyle.fontSize ?? 16.0,
+    );
+
+    TextStyle numberTextStyle =
+        widget.lineNumberStyle.textStyle ?? const TextStyle();
+    final numberColor =
+        (styles?[rootKey]?.color ?? defaultText).withOpacity(0.7);
+
+    numberTextStyle = numberTextStyle.copyWith(
+      color: numberTextStyle.color ?? numberColor,
+      fontSize: textStyle.fontSize,
+      fontFamily: textStyle.fontFamily,
+    );
+
+    final cursorColor =
+        widget.cursorColor ?? styles?[rootKey]?.color ?? defaultText;
+
+    TextField? lineNumberCol;
+    Container? numberCol;
+
+    if (widget.lineNumbers) {
+      lineNumberCol = TextField(
+        smartQuotesType: widget.smartQuotesType,
+        scrollPadding: widget.padding,
+        style: numberTextStyle,
+        controller: _numberController,
+        enabled: false,
+        minLines: widget.minLines,
+        maxLines: widget.maxLines,
+        selectionControls: widget.selectionControls,
+        expands: widget.expands,
+        scrollController: _numberScroll,
+        decoration: InputDecoration(
+          disabledBorder: InputBorder.none,
+          isDense: widget.isDense,
+        ),
+        textAlign: widget.lineNumberStyle.textAlign,
+        textAlignVertical: widget.textAlignVertical,
+      );
+
+      numberCol = Container(
+        width: widget.lineNumberStyle.width,
+        padding: EdgeInsets.only(
+          left: widget.padding.left,
+          right: widget.lineNumberStyle.margin / 2,
+        ),
+        color: widget.lineNumberStyle.background,
+        child: lineNumberCol,
+      );
+    }
+
+    final codeField = TextField(
+      keyboardType: widget.keyboardType,
+      smartQuotesType: widget.smartQuotesType,
+      focusNode: _focusNode,
+      onTap: widget.onTap,
+      scrollPadding: widget.padding,
+      style: textStyle,
+      controller: widget.controller,
+      minLines: widget.minLines,
+      selectionControls: widget.selectionControls,
+      maxLines: widget.maxLines,
+      expands: widget.expands,
+      scrollController: _codeScroll,
+      textAlignVertical: widget.textAlignVertical,
+      decoration: InputDecoration(
+        disabledBorder: InputBorder.none,
+        border: InputBorder.none,
+        focusedBorder: InputBorder.none,
+        isDense: widget.isDense,
+      ),
+      cursorColor: cursorColor,
+      autocorrect: false,
+      enableSuggestions: false,
+      enabled: widget.enabled,
+      onChanged: widget.onChanged,
+      readOnly: widget.readOnly,
+    );
+
+    final codeCol = Theme(
+      data: Theme.of(context).copyWith(
+        textSelectionTheme: widget.textSelectionTheme,
+      ),
+      child: LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          return widget.wrap
+              ? codeField
+              : _wrapInScrollView(codeField, textStyle, constraints.maxWidth);
+        },
+      ),
+    );
+
+    return Container(
+      decoration: widget.decoration,
+      color: backgroundCol,
+      padding: !widget.lineNumbers ? const EdgeInsets.only(left: 8) : null,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (widget.lineNumbers && numberCol != null) numberCol,
+          Expanded(child: codeCol),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/workbook_navigator.dart
+++ b/lib/presentation/workbook_navigator.dart
@@ -29,6 +29,7 @@ import 'widgets/menu_page_view.dart';
 import 'widgets/notes_page_view.dart';
 import 'widgets/sheet_grid.dart';
 import 'widgets/workbook_page_tab_bar.dart';
+import 'widgets/top_aligned_code_field.dart';
 import 'workbook_page_display.dart';
 
 class CustomAction {
@@ -1217,7 +1218,7 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator> {
             Positioned.fill(
               child: IgnorePointer(
                 ignoring: !_scriptEditorMutable,
-                child: CodeField(
+                child: TopAlignedCodeField(
                   controller: _scriptEditorController,
                   expands: true,
                   textStyle: const TextStyle(


### PR DESCRIPTION
## Summary
- default the custom TopAlignedCodeField widget to use top vertical alignment
- rely on the default alignment from TopAlignedCodeField inside the workbook navigator

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e021ac415883268d70c82a7ef12038