### PR TITLE
Remove duplicate script editor alignment

### DIFF
--- a/lib/presentation/workbook_navigator.dart
+++ b/lib/presentation/workbook_navigator.dart
@@ -1221,7 +1221,6 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator> {
                 child: TopAlignedCodeField(
                   controller: _scriptEditorController,
                   expands: true,
-                  textAlignVertical: TextAlignVertical.top,
                   textStyle: const TextStyle(
                     fontFamily: 'monospace',
                     fontSize: 13,


### PR DESCRIPTION
## Summary
- remove the duplicated `textAlignVertical` parameter from the script editor configuration to avoid argument conflicts

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e041fe1b4883268b1c3279e10c24a0