### PR TITLE
Support tree layout for menu pages

### DIFF
--- a/lib/application/commands/add_menu_page_command.dart
+++ b/lib/application/commands/add_menu_page_command.dart
@@ -22,10 +22,19 @@ class AddMenuPageCommand extends WorkbookCommand {
 
   @override
   WorkbookCommandResult performExecute(WorkbookCommandContext context) {
+    final initialMetadata = Map<String, Object?>.from(metadata);
+    final tree = layout == 'tree'
+        ? _resolveTree(initialMetadata, context.workbook)
+        : null;
+    if (tree != null) {
+      initialMetadata['tree'] = tree.toMetadata();
+    }
+
     final newPage = MenuPage(
       name: _generatePageName(context.workbook),
       layout: layout,
-      metadata: metadata,
+      metadata: initialMetadata,
+      tree: tree,
     );
     final pages = context.workbook.pages.toList(growable: true)..add(newPage);
     final updatedWorkbook = Workbook(pages: pages);
@@ -39,4 +48,18 @@ class AddMenuPageCommand extends WorkbookCommand {
   }
 
   String _generatePageName(Workbook workbook) => 'Menu principal';
+
+  MenuTree? _resolveTree(
+    Map<String, Object?> metadata,
+    Workbook workbook,
+  ) {
+    if (metadata.containsKey('tree')) {
+      final parsed = MenuTree.fromMetadata(metadata['tree']);
+      if (parsed.isNotEmpty) {
+        return parsed;
+      }
+    }
+    final generated = MenuTree.fromWorkbookPages(workbook.pages);
+    return generated.isEmpty ? null : generated;
+  }
 }

--- a/lib/application/commands/set_page_layout_command.dart
+++ b/lib/application/commands/set_page_layout_command.dart
@@ -48,7 +48,23 @@ class SetPageLayoutCommand extends WorkbookCommand {
       return WorkbookCommandResult(workbook: context.workbook);
     }
 
-    final updatedPage = page.copyWith(layout: layout);
+    MenuTree? treeOverride;
+    if (layout == 'tree') {
+      if (page.tree.isNotEmpty) {
+        treeOverride = page.tree;
+      } else {
+        final generated = MenuTree.fromWorkbookPages(context.workbook.pages);
+        if (generated.isNotEmpty) {
+          treeOverride = generated;
+        }
+      }
+    }
+
+    final updatedPage = page.copyWith(
+      layout: layout,
+      tree: treeOverride,
+      metadata: treeOverride != null ? {'tree': treeOverride.toMetadata()} : null,
+    );
     final updatedWorkbook = replacePage(
       context.workbook,
       targetIndex,

--- a/lib/domain/menu_page.dart
+++ b/lib/domain/menu_page.dart
@@ -2,17 +2,194 @@ import 'package:meta/meta.dart';
 
 import 'workbook_page.dart';
 
+/// Represents a structured entry in a [MenuPage] tree.
+@immutable
+class MenuTreeNode {
+  const MenuTreeNode._({
+    required this.id,
+    required this.label,
+    required List<MenuTreeNode> children,
+    this.pageName,
+  }) : _children = List<MenuTreeNode>.unmodifiable(children);
+
+  /// Builds a section node containing the provided [children].
+  factory MenuTreeNode.section({
+    required String id,
+    required String label,
+    List<MenuTreeNode> children = const [],
+  }) {
+    return MenuTreeNode._(
+      id: id,
+      label: label,
+      children: children,
+    );
+  }
+
+  /// Builds a leaf node targeting a workbook page by [pageName].
+  factory MenuTreeNode.leaf({
+    required String id,
+    required String label,
+    required String pageName,
+  }) {
+    return MenuTreeNode._(
+      id: id,
+      label: label,
+      children: const [],
+      pageName: pageName,
+    );
+  }
+
+  /// Attempts to build a node from serialised [data].
+  static MenuTreeNode? tryParse(Object? data) {
+    if (data is! Map<String, Object?>) {
+      return null;
+    }
+    final id = data['id']?.toString();
+    final label = data['label']?.toString();
+    if (id == null || label == null) {
+      return null;
+    }
+    final pageName = data['page']?.toString();
+    final childrenData = data['children'];
+    if (pageName != null) {
+      return MenuTreeNode.leaf(id: id, label: label, pageName: pageName);
+    }
+    final children = <MenuTreeNode>[];
+    if (childrenData is List) {
+      for (final entry in childrenData) {
+        final parsed = MenuTreeNode.tryParse(entry);
+        if (parsed != null) {
+          children.add(parsed);
+        }
+      }
+    }
+    return MenuTreeNode.section(id: id, label: label, children: children);
+  }
+
+  /// Unique identifier for stateful UI elements.
+  final String id;
+
+  /// User-facing label for the section or leaf.
+  final String label;
+
+  final List<MenuTreeNode> _children;
+
+  /// Child nodes when representing a section.
+  List<MenuTreeNode> get children => _children;
+
+  /// Name of the targeted workbook page for leaf nodes.
+  final String? pageName;
+
+  /// Whether this node represents a leaf targeting a workbook page.
+  bool get isLeaf => pageName != null;
+
+  /// Serialises the node to a JSON-compatible representation.
+  Map<String, Object?> toMetadata() {
+    return {
+      'id': id,
+      'label': label,
+      if (pageName != null) 'page': pageName,
+      if (_children.isNotEmpty)
+        'children': _children.map((child) => child.toMetadata()).toList(),
+    };
+  }
+}
+
+/// Container for the tree displayed by a [MenuPage].
+@immutable
+class MenuTree {
+  const MenuTree({List<MenuTreeNode> nodes = const []})
+      : _nodes = List<MenuTreeNode>.unmodifiable(nodes);
+
+  const MenuTree.empty() : _nodes = const [];
+
+  /// Attempts to build a tree from serialised [data].
+  factory MenuTree.fromMetadata(Object? data) {
+    if (data is Map<String, Object?>) {
+      final rawNodes = data['nodes'] ?? data['children'] ?? data['sections'];
+      if (rawNodes is List) {
+        return MenuTree(nodes: _parseNodeList(rawNodes));
+      }
+    } else if (data is List) {
+      return MenuTree(nodes: _parseNodeList(data));
+    }
+    return const MenuTree.empty();
+  }
+
+  /// Builds a simple tree grouping existing workbook pages.
+  factory MenuTree.fromWorkbookPages(Iterable<WorkbookPage> pages) {
+    final leaves = <MenuTreeNode>[];
+    for (final page in pages) {
+      if (page is MenuPage) {
+        continue;
+      }
+      leaves.add(
+        MenuTreeNode.leaf(
+          id: 'page-${page.name}',
+          label: page.name,
+          pageName: page.name,
+        ),
+      );
+    }
+    if (leaves.isEmpty) {
+      return const MenuTree.empty();
+    }
+    return MenuTree(
+      nodes: [
+        MenuTreeNode.section(
+          id: 'root-pages',
+          label: 'Pages',
+          children: leaves,
+        ),
+      ],
+    );
+  }
+
+  static List<MenuTreeNode> _parseNodeList(List<Object?> data) {
+    final nodes = <MenuTreeNode>[];
+    for (final entry in data) {
+      final parsed = MenuTreeNode.tryParse(entry);
+      if (parsed != null) {
+        nodes.add(parsed);
+      }
+    }
+    return nodes;
+  }
+
+  final List<MenuTreeNode> _nodes;
+
+  /// Top-level nodes of the menu tree.
+  List<MenuTreeNode> get nodes => _nodes;
+
+  /// Whether the tree currently exposes any node.
+  bool get isEmpty => _nodes.isEmpty;
+
+  /// Convenience getter mirroring [isEmpty].
+  bool get isNotEmpty => _nodes.isNotEmpty;
+
+  /// Serialises the tree to a JSON-compatible representation.
+  Map<String, Object?> toMetadata() {
+    return {
+      'nodes': _nodes.map((node) => node.toMetadata()).toList(),
+    };
+  }
+}
+
 /// Represents a navigational menu page in the workbook.
 @immutable
 class MenuPage extends WorkbookPage {
   MenuPage({
     required this.name,
     String layout = 'list',
+    MenuTree? tree,
     Map<String, Object?> metadata = const {},
   })  : assert(name.isNotEmpty, 'Menu pages must be named.'),
+        tree = tree ?? MenuTree.fromMetadata(metadata['tree']),
         _metadata = Map<String, Object?>.unmodifiable({
           ...metadata,
           'layout': layout,
+          'tree': (tree ?? MenuTree.fromMetadata(metadata['tree']))
+              .toMetadata(),
         });
 
   @override
@@ -26,6 +203,9 @@ class MenuPage extends WorkbookPage {
   @override
   Map<String, Object?> get metadata => _metadata;
 
+  /// Structured metadata representing the navigational tree.
+  final MenuTree tree;
+
   /// Current layout identifier stored in the metadata.
   String get layout => metadata['layout'] as String? ?? 'list';
 
@@ -33,6 +213,7 @@ class MenuPage extends WorkbookPage {
   MenuPage copyWith({
     String? name,
     String? layout,
+    MenuTree? tree,
     Map<String, Object?>? metadata,
   }) {
     final nextMetadata = Map<String, Object?>.from(_metadata);
@@ -42,10 +223,20 @@ class MenuPage extends WorkbookPage {
     if (layout != null) {
       nextMetadata['layout'] = layout;
     }
+    MenuTree resolvedTree;
+    if (tree != null) {
+      resolvedTree = tree;
+    } else if (metadata != null && metadata.containsKey('tree')) {
+      resolvedTree = MenuTree.fromMetadata(nextMetadata['tree']);
+    } else {
+      resolvedTree = this.tree;
+    }
+    nextMetadata['tree'] = resolvedTree.toMetadata();
     return MenuPage(
       name: name ?? this.name,
       layout: nextMetadata['layout'] as String? ?? 'list',
       metadata: nextMetadata,
+      tree: resolvedTree,
     );
   }
 }

--- a/lib/presentation/widgets/menu_page_view.dart
+++ b/lib/presentation/widgets/menu_page_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../domain/menu_page.dart';
 import '../../domain/workbook.dart';
 import '../workbook_page_display.dart';
+import 'menu_tree_view.dart';
 
 class MenuPageView extends StatelessWidget {
   const MenuPageView({
@@ -29,18 +30,6 @@ class MenuPageView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final destinations = <_MenuDestination>[
-      for (var index = 0; index < workbook.pages.length; index++)
-        if (workbook.pages[index] is! MenuPage)
-          _MenuDestination(
-            title: workbook.pages[index].name,
-            subtitle: workbookPageDescription(workbook.pages[index]),
-            icon: workbookPageIcon(workbook.pages[index]),
-            pageIndex: index,
-            canRemove: canRemovePage(index),
-          ),
-    ];
-
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
       child: Column(
@@ -75,31 +64,58 @@ class MenuPageView extends StatelessWidget {
             ),
           ],
           const SizedBox(height: 16),
-          Expanded(
-            child: destinations.isEmpty
-                ? Center(
-                    child: Text(
-                      'Aucune page disponible pour le moment.',
-                      style: theme.textTheme.bodyMedium,
-                    ),
-                  )
-                : ListView.separated(
-                    padding: EdgeInsets.zero,
-                    itemCount: destinations.length,
-                    separatorBuilder: (_, __) => const SizedBox(height: 12),
-                    itemBuilder: (context, index) {
-                      final destination = destinations[index];
-                      return _MenuDestinationCard(
-                        destination: destination,
-                        onOpenPage: onOpenPage,
-                        onRemovePage: onRemovePage,
-                        enableEditing: enableEditing,
-                      );
-                    },
-                  ),
-          ),
+          Expanded(child: _buildLayout(context)),
         ],
       ),
+    );
+  }
+
+  Widget _buildLayout(BuildContext context) {
+    if (page.layout == 'tree') {
+      return MenuTreeView(
+        page: page,
+        workbook: workbook,
+        onOpenPage: onOpenPage,
+        onRemovePage: onRemovePage,
+        canRemovePage: canRemovePage,
+        enableEditing: enableEditing,
+      );
+    }
+
+    final destinations = <_MenuDestination>[
+      for (var index = 0; index < workbook.pages.length; index++)
+        if (workbook.pages[index] is! MenuPage)
+          _MenuDestination(
+            title: workbook.pages[index].name,
+            subtitle: workbookPageDescription(workbook.pages[index]),
+            icon: workbookPageIcon(workbook.pages[index]),
+            pageIndex: index,
+            canRemove: canRemovePage(index),
+          ),
+    ];
+
+    if (destinations.isEmpty) {
+      return Center(
+        child: Text(
+          'Aucune page disponible pour le moment.',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      );
+    }
+
+    return ListView.separated(
+      padding: EdgeInsets.zero,
+      itemCount: destinations.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final destination = destinations[index];
+        return _MenuDestinationCard(
+          destination: destination,
+          onOpenPage: onOpenPage,
+          onRemovePage: onRemovePage,
+          enableEditing: enableEditing,
+        );
+      },
     );
   }
 }

--- a/lib/presentation/widgets/menu_tree_view.dart
+++ b/lib/presentation/widgets/menu_tree_view.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/menu_page.dart';
+import '../../domain/workbook.dart';
+import '../../domain/workbook_page.dart';
+import '../workbook_page_display.dart';
+
+class MenuTreeView extends StatelessWidget {
+  const MenuTreeView({
+    super.key,
+    required this.page,
+    required this.workbook,
+    required this.onOpenPage,
+    required this.onRemovePage,
+    required this.canRemovePage,
+    required this.enableEditing,
+  });
+
+  final MenuPage page;
+  final Workbook workbook;
+  final ValueChanged<int> onOpenPage;
+  final ValueChanged<int> onRemovePage;
+  final bool Function(int pageIndex) canRemovePage;
+  final bool enableEditing;
+
+  @override
+  Widget build(BuildContext context) {
+    if (page.tree.isEmpty) {
+      return Center(
+        child: Text(
+          'Aucune entrée de menu définie pour le moment.',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      );
+    }
+
+    return ListView(
+      padding: EdgeInsets.zero,
+      children: [
+        for (final node in page.tree.nodes) _buildNode(context, node, 0),
+      ],
+    );
+  }
+
+  Widget _buildNode(BuildContext context, MenuTreeNode node, int depth) {
+    if (node.isLeaf) {
+      return _buildLeaf(context, node, depth);
+    }
+    final children = node.children;
+    final theme = Theme.of(context);
+    return Padding(
+      padding: EdgeInsets.only(left: depth * 12.0, bottom: 12),
+      child: Card(
+        child: ExpansionTile(
+          key: PageStorageKey<String>('menu-tree-${node.id}'),
+          title: Text(
+            node.label,
+            style: theme.textTheme.titleMedium,
+          ),
+          childrenPadding: const EdgeInsets.only(left: 12, right: 12, bottom: 12),
+          children: [
+            if (children.isEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    'Aucun élément',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ),
+              )
+            else
+              for (final child in children)
+                _buildNode(context, child, depth + 1),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLeaf(BuildContext context, MenuTreeNode node, int depth) {
+    final resolved = _resolvePage(node.pageName);
+    final theme = Theme.of(context);
+    final padding = EdgeInsets.only(left: depth * 12.0, bottom: 12);
+    if (resolved == null) {
+      return Padding(
+        padding: padding,
+        child: Card(
+          color: theme.colorScheme.errorContainer,
+          child: ListTile(
+            leading: const Icon(Icons.error_outline),
+            title: Text(
+              'Page introuvable',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onErrorContainer,
+              ),
+            ),
+            subtitle: Text(
+              "Impossible de trouver la page \"${node.pageName}\".",
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onErrorContainer,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    final page = resolved.page;
+    final pageIndex = resolved.index;
+    final canRemove = canRemovePage(pageIndex);
+    final colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: padding,
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              CircleAvatar(
+                radius: 20,
+                backgroundColor: colorScheme.primary.withOpacity(0.1),
+                child: Icon(
+                  workbookPageIcon(page),
+                  color: colorScheme.primary,
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      node.label.isEmpty ? page.name : node.label,
+                      style: theme.textTheme.titleMedium,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      workbookPageDescription(page),
+                      style: theme.textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 16),
+              Wrap(
+                spacing: 8,
+                children: [
+                  FilledButton.tonalIcon(
+                    onPressed: () => onOpenPage(pageIndex),
+                    icon: const Icon(Icons.open_in_new),
+                    label: const Text('Ouvrir'),
+                  ),
+                  if (enableEditing && canRemove)
+                    IconButton(
+                      tooltip: 'Supprimer',
+                      onPressed: () => onRemovePage(pageIndex),
+                      icon: const Icon(Icons.delete_outline),
+                      splashRadius: 18,
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  _ResolvedPage? _resolvePage(String? pageName) {
+    if (pageName == null) {
+      return null;
+    }
+    for (var index = 0; index < workbook.pages.length; index++) {
+      final candidate = workbook.pages[index];
+      if (candidate.name == pageName && candidate is! MenuPage) {
+        return _ResolvedPage(page: candidate, index: index);
+      }
+    }
+    return null;
+  }
+}
+
+class _ResolvedPage {
+  const _ResolvedPage({required this.page, required this.index});
+
+  final WorkbookPage page;
+  final int index;
+}


### PR DESCRIPTION
## Summary
- define a serialisable menu tree model that augments menu page metadata with hierarchical nodes
- add a tree-based menu view with expandable groups and actions on each leaf entry
- teach menu page rendering and commands to initialise and switch between list and tree layouts

## Testing
- flutter test *(fails: flutter command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0609f38e48326a48124468f48e4ca