### PR TITLE
Ensure documentation tab is available in fullscreen overlay

### DIFF
--- a/lib/presentation/workbook_navigator/admin_workspace_view.dart
+++ b/lib/presentation/workbook_navigator/admin_workspace_view.dart
@@ -253,52 +253,74 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
       return Positioned.fill(
         child: Theme(
           data: theme,
-          child: Scaffold(
-            backgroundColor: theme.colorScheme.surface,
-            body: SafeArea(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            'Espace de développement',
-                            style: theme.textTheme.titleMedium,
+          child: DefaultTabController(
+            length: 2,
+            child: Scaffold(
+              backgroundColor: theme.colorScheme.surface,
+              body: SafeArea(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              'Espace de développement',
+                              style: theme.textTheme.titleMedium,
+                            ),
                           ),
-                        ),
-                        FilledButton.icon(
-                          onPressed: _handleExitScriptEditorFullscreen,
-                          icon: const Icon(Icons.fullscreen_exit),
-                          label: const Text('Quitter le plein écran'),
-                        ),
-                        const SizedBox(width: 12),
-                        ...buildActionButtons(includeFullscreenToggle: false),
-                      ],
-                    ),
-                  ),
-                  const Divider(height: 1),
-                  Expanded(
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        SizedBox(
-                          width: 240,
-                          child: _buildScriptLibraryPanel(context),
-                        ),
-                        const VerticalDivider(width: 1),
-                        Expanded(
-                          child: Padding(
-                            padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
-                            child: buildEditorContent(fullscreen: true),
+                          FilledButton.icon(
+                            onPressed: _handleExitScriptEditorFullscreen,
+                            icon: const Icon(Icons.fullscreen_exit),
+                            label: const Text('Quitter le plein écran'),
                           ),
-                        ),
-                      ],
+                          const SizedBox(width: 12),
+                          ...buildActionButtons(includeFullscreenToggle: false),
+                        ],
+                      ),
                     ),
-                  ),
-                ],
+                    const Divider(height: 1),
+                    Container(
+                      color: theme.colorScheme.surface,
+                      child: TabBar(
+                        labelColor: theme.colorScheme.primary,
+                        indicatorColor: theme.colorScheme.primary,
+                        tabs: const [
+                          Tab(icon: Icon(Icons.code), text: 'Scripts'),
+                          Tab(
+                            icon: Icon(Icons.menu_book_outlined),
+                            text: 'Documentation',
+                          ),
+                        ],
+                      ),
+                    ),
+                    Expanded(
+                      child: TabBarView(
+                        children: [
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              SizedBox(
+                                width: 240,
+                                child: _buildScriptLibraryPanel(context),
+                              ),
+                              const VerticalDivider(width: 1),
+                              Expanded(
+                                child: Padding(
+                                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+                                  child: buildEditorContent(fullscreen: true),
+                                ),
+                              ),
+                            ],
+                          ),
+                          _buildAdminDocumentationTab(context),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- wrap the admin fullscreen script editor overlay in a DefaultTabController mirroring the base view
- keep the documentation tab available and styled when entering fullscreen without removing existing actions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e13f9d7c9c8326bf2d32b23f8ca05d