### PR TITLE
Add toggle for admin workspace visibility

### DIFF
--- a/lib/presentation/workbook_navigator/admin_workspace_view.dart
+++ b/lib/presentation/workbook_navigator/admin_workspace_view.dart
@@ -65,7 +65,7 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
           ),
         ),
         _ScriptEditorOverlayHost(
-          isActive: _scriptEditorFullscreen,
+          isActive: _adminWorkspaceVisible && _scriptEditorFullscreen,
           overlayBuilder: overlayBuilder,
         ),
       ],
@@ -221,6 +221,15 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
                   style: theme.textTheme.titleMedium,
                 ),
               ),
+              TextButton.icon(
+                onPressed: () {
+                  _handleExitScriptEditorFullscreen();
+                  _toggleAdminWorkspaceVisibility();
+                },
+                icon: const Icon(Icons.visibility_off_outlined),
+                label: const Text('Masquer'),
+              ),
+              const SizedBox(width: 12),
               ...buildActionButtons(includeFullscreenToggle: true),
             ],
           ),
@@ -271,6 +280,15 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
                               style: theme.textTheme.titleMedium,
                             ),
                           ),
+                          TextButton.icon(
+                            onPressed: () {
+                              _handleExitScriptEditorFullscreen();
+                              _toggleAdminWorkspaceVisibility();
+                            },
+                            icon: const Icon(Icons.visibility_off_outlined),
+                            label: const Text('Masquer'),
+                          ),
+                          const SizedBox(width: 12),
                           FilledButton.icon(
                             onPressed: _handleExitScriptEditorFullscreen,
                             icon: const Icon(Icons.fullscreen_exit),

--- a/lib/presentation/workbook_navigator/workbook_navigator_state.dart
+++ b/lib/presentation/workbook_navigator/workbook_navigator_state.dart
@@ -41,6 +41,7 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator>
   bool _suppressScriptEditorChanges = false;
   bool _scriptEditorFullscreen = false;
   bool _scriptEditorSplitPreview = false;
+  bool _adminWorkspaceVisible = true;
   bool _scriptEditorMutable = true;
   WidgetBuilder? _scriptEditorOverlayBuilder;
   late int _currentPageIndex;
@@ -64,6 +65,7 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator>
     _customActionTemplateController = TextEditingController();
     _sharedScriptKeyController.addListener(_handleSharedScriptKeyChanged);
     if (_isAdmin) {
+      _adminWorkspaceVisible = true;
       _initialiseCustomActions();
       unawaited(_refreshScriptLibrary());
     }
@@ -104,6 +106,11 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator>
       widget.commandManager.addListener(_handleManagerChanged);
     }
     if (!oldWidget.isAdmin && widget.isAdmin) {
+      if (!_adminWorkspaceVisible) {
+        setState(() {
+          _adminWorkspaceVisible = true;
+        });
+      }
       _initialiseCustomActions();
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) {
@@ -117,6 +124,12 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator>
     if (oldWidget.isAdmin && !widget.isAdmin) {
       _updateScriptTree();
     }
+  }
+
+  void _toggleAdminWorkspaceVisibility() {
+    setState(() {
+      _adminWorkspaceVisible = !_adminWorkspaceVisible;
+    });
   }
 
   @override
@@ -368,6 +381,26 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator>
           return LayoutBuilder(
             builder: (context, constraints) {
               final isWide = constraints.maxWidth >= 1100;
+              if (!_adminWorkspaceVisible) {
+                return Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Stack(
+                    children: [
+                      Positioned.fill(child: workbookSurface),
+                      Positioned(
+                        top: 12,
+                        right: 12,
+                        child: FilledButton.icon(
+                          onPressed: _toggleAdminWorkspaceVisibility,
+                          icon: const Icon(Icons.visibility_outlined),
+                          label:
+                              const Text('Afficher l’espace de développement'),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }
               if (isWide) {
                 return Row(
                   crossAxisAlignment: CrossAxisAlignment.stretch,


### PR DESCRIPTION
## Summary
- introduce an `_adminWorkspaceVisible` flag so the admin workspace can be shown or hidden and reset it whenever admin mode is enabled
- render the workbook surface alone with a reopen button when the admin workspace is hidden and disable the fullscreen overlay accordingly
- add "Masquer" controls to the admin workspace headers to exit fullscreen and hide the panel on demand

## Testing
- flutter analyze *(fails: flutter is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e143cd15b4832682feb2924a8d4c55