### PR TITLE
Tighten admin workspace toggle tab

### DIFF
--- a/lib/presentation/workbook_navigator/workbook_navigator_state.dart
+++ b/lib/presentation/workbook_navigator/workbook_navigator_state.dart
@@ -384,18 +384,25 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator>
               if (!_adminWorkspaceVisible) {
                 return Padding(
                   padding: const EdgeInsets.all(16),
-                  child: Stack(
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Positioned.fill(child: workbookSurface),
-                      Positioned(
-                        top: 12,
-                        right: 12,
-                        child: FilledButton.icon(
-                          onPressed: _toggleAdminWorkspaceVisibility,
-                          icon: const Icon(Icons.visibility_outlined),
-                          label:
-                              const Text('Afficher l’espace de développement'),
+                      SizedBox(
+                        width: _kWorkspaceToggleTabWidth,
+                        child: Align(
+                          alignment: Alignment.topLeft,
+                          child: Padding(
+                            padding: const EdgeInsets.only(top: 24),
+                            child: _buildWorkspaceToggleTab(
+                              context: context,
+                              expanded: false,
+                              onPressed: _toggleAdminWorkspaceVisibility,
+                            ),
+                          ),
                         ),
+                      ),
+                      Expanded(
+                        child: workbookSurface,
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- shrink the admin workspace toggle tab to an arrow-only control while keeping shared tooltip semantics
- adjust the hidden and expanded layouts so the slimmer tab sits along the left seam and remains clickable

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e1466287bc8326b7180b7768de0fb7