### PR TITLE
Fix admin workspace toggle arrow direction

### DIFF
--- a/lib/presentation/workbook_navigator/admin_workspace_view.dart
+++ b/lib/presentation/workbook_navigator/admin_workspace_view.dart
@@ -13,8 +13,8 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
   }) {
     final theme = Theme.of(context);
     final icon = expanded
-        ? Icons.arrow_back_ios_new
-        : Icons.arrow_forward_ios;
+        ? Icons.arrow_forward_ios
+        : Icons.arrow_back_ios_new;
     final foregroundColor = theme.colorScheme.primary;
     final backgroundColor = theme.colorScheme.surface;
     final borderColor = theme.colorScheme.outlineVariant;


### PR DESCRIPTION
## Summary
- adjust the admin workspace toggle so the expanded state arrow points toward the hidden workspace and the collapsed state arrow points back to the workbook
- ensure the shared helper continues to supply the corrected icon orientation everywhere it is used

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14ca844188326a60ac6eb92d6bb37