### PR TITLE
Reposition admin workspace toggle tab

### DIFF
--- a/lib/presentation/workbook_navigator/workbook_navigator_state.dart
+++ b/lib/presentation/workbook_navigator/workbook_navigator_state.dart
@@ -384,25 +384,24 @@ class _WorkbookNavigatorState extends State<WorkbookNavigator>
               if (!_adminWorkspaceVisible) {
                 return Padding(
                   padding: const EdgeInsets.all(16),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
+                  child: Stack(
+                    fit: StackFit.expand,
                     children: [
-                      SizedBox(
-                        width: _kWorkspaceToggleTabWidth,
-                        child: Align(
-                          alignment: Alignment.topLeft,
-                          child: Padding(
-                            padding: const EdgeInsets.only(top: 24),
-                            child: _buildWorkspaceToggleTab(
-                              context: context,
-                              expanded: false,
-                              onPressed: _toggleAdminWorkspaceVisibility,
-                            ),
+                      Padding(
+                        padding:
+                            const EdgeInsets.only(right: _kWorkspaceToggleTabWidth),
+                        child: workbookSurface,
+                      ),
+                      Align(
+                        alignment: Alignment.topRight,
+                        child: SafeArea(
+                          minimum: const EdgeInsets.only(top: 24),
+                          child: _buildWorkspaceToggleTab(
+                            context: context,
+                            expanded: false,
+                            onPressed: _toggleAdminWorkspaceVisibility,
                           ),
                         ),
-                      ),
-                      Expanded(
-                        child: workbookSurface,
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- stack the workbook surface and toggle button when the admin workspace is hidden
- keep the toggle anchored to the workbook edge with SafeArea padding so it stays reachable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e14d18aafc83269547ecbf18b5c8f2