### PR TITLE
Reduce admin workspace toggle tab dimensions

### DIFF
--- a/lib/presentation/workbook_navigator/admin_workspace_view.dart
+++ b/lib/presentation/workbook_navigator/admin_workspace_view.dart
@@ -1,7 +1,7 @@
 part of 'workbook_navigator.dart';
 
-const double _kWorkspaceToggleTabWidth = 48;
-const double _kWorkspaceToggleTabHeight = 80;
+const double _kWorkspaceToggleTabWidth = 40;
+const double _kWorkspaceToggleTabHeight = 64;
 const String _kWorkspaceToggleTooltip =
     'Afficher/Masquer l’espace de développement';
 
@@ -104,7 +104,7 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
           child: Align(
             alignment: Alignment.topLeft,
             child: Padding(
-              padding: const EdgeInsets.only(top: 24),
+              padding: const EdgeInsets.only(top: 16),
               child: _buildWorkspaceToggleTab(
                 context: context,
                 expanded: true,
@@ -416,7 +416,7 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
                       ],
                     ),
                     Positioned(
-                      top: 32,
+                      top: 24,
                       left: -_kWorkspaceToggleTabWidth,
                       child: _buildWorkspaceToggleTab(
                         context: context,


### PR DESCRIPTION
## Summary
- shrink the admin workspace toggle tab dimensions to the new compact size
- adjust the related padding so the updated sizing stays aligned, including the fullscreen overlay tab

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14e53da888326a6c533db50b538b3