### PR TITLE
Align admin workspace toggle tab in header

### DIFF
--- a/lib/presentation/workbook_navigator/admin_workspace_view.dart
+++ b/lib/presentation/workbook_navigator/admin_workspace_view.dart
@@ -1,7 +1,7 @@
 part of 'workbook_navigator.dart';
 
-const double _kWorkspaceToggleTabWidth = 40;
-const double _kWorkspaceToggleTabHeight = 64;
+const double _kWorkspaceToggleTabWidth = 36;
+const double _kWorkspaceToggleTabHeight = 48;
 const String _kWorkspaceToggleTooltip =
     'Afficher/Masquer l’espace de développement';
 
@@ -27,7 +27,7 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
         child: SizedBox(
           width: _kWorkspaceToggleTabWidth,
           child: Align(
-            alignment: Alignment.centerRight,
+            alignment: Alignment.topRight,
             child: Material(
               color: Colors.transparent,
               child: InkWell(
@@ -55,7 +55,7 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
                     ],
                   ),
                   child: Center(
-                    child: Icon(icon, size: 16, color: foregroundColor),
+                    child: Icon(icon, size: 14, color: foregroundColor),
                   ),
                 ),
               ),
@@ -279,16 +279,23 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
           child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Padding(
                 padding: const EdgeInsets.only(right: 12),
-                child: _buildWorkspaceToggleTab(
-                  context: context,
-                  expanded: true,
-                  onPressed: () {
-                    _handleExitScriptEditorFullscreen();
-                    _toggleAdminWorkspaceVisibility();
-                  },
+                child: SizedBox(
+                  height: _kWorkspaceToggleTabHeight,
+                  child: Align(
+                    alignment: Alignment.topLeft,
+                    child: _buildWorkspaceToggleTab(
+                      context: context,
+                      expanded: true,
+                      onPressed: () {
+                        _handleExitScriptEditorFullscreen();
+                        _toggleAdminWorkspaceVisibility();
+                      },
+                    ),
+                  ),
                 ),
               ),
               Expanded(
@@ -340,16 +347,23 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
                       child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Padding(
                             padding: const EdgeInsets.only(right: 12),
-                            child: _buildWorkspaceToggleTab(
-                              context: context,
-                              expanded: true,
-                              onPressed: () {
-                                _handleExitScriptEditorFullscreen();
-                                _toggleAdminWorkspaceVisibility();
-                              },
+                            child: SizedBox(
+                              height: _kWorkspaceToggleTabHeight,
+                              child: Align(
+                                alignment: Alignment.topLeft,
+                                child: _buildWorkspaceToggleTab(
+                                  context: context,
+                                  expanded: true,
+                                  onPressed: () {
+                                    _handleExitScriptEditorFullscreen();
+                                    _toggleAdminWorkspaceVisibility();
+                                  },
+                                ),
+                              ),
                             ),
                           ),
                           Expanded(


### PR DESCRIPTION
## Summary
- reduce the workspace toggle tab dimensions so it occupies less space in the header
- align the toggle tab to the top edge in both standard and fullscreen admin layouts

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e154bc28808326adfb566d9ed7e97b