### PR TITLE
Fix python FFI import path resolution

### DIFF
--- a/lib/application/scripts/runtime.dart
+++ b/lib/application/scripts/runtime.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:python_ffi/python_ffi_dart.dart';
+import 'package:python_ffi_dart/python_ffi_dart.dart';
 
 import '../../domain/menu_page.dart';
 import '../../domain/notes_page.dart';


### PR DESCRIPTION
## Summary
- update the script runtime to use the correct `python_ffi_dart` package import path

## Testing
- dart analyze *(fails: `bash: command not found: dart` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e19d25cdac8326a6154a0a855b8f3e