### PR TITLE
Align script runtime sheet metadata usage

### DIFF
--- a/lib/application/scripts/runtime.dart
+++ b/lib/application/scripts/runtime.dart
@@ -281,10 +281,7 @@ class ScriptRuntime {
 
   Map<String, Object?> _sheetContext(Sheet sheet) {
     return <String, Object?>{
-      'rowCount': sheet.rowCount,
-      'columnCount': sheet.columnCount,
-      'frozenColumns': sheet.frozenColumns,
-      'frozenRows': sheet.frozenRows,
+      ...sheet.metadata,
     };
   }
 


### PR DESCRIPTION
## Summary
- stop exporting undefined frozen row/column properties in the script runtime
- source sheet context data directly from the Sheet metadata to keep exports consistent

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e19f4af63883269cffb7cbb354b091