### PR TITLE
feat: switch script editor to python modules

### DIFF
--- a/assets/scripts/global/default.py
+++ b/assets/scripts/global/default.py
@@ -1,16 +1,16 @@
 """Script global d'exemple pour Optima."""
 
 
-def on_workbook_open(context):
+def on_workbook_open(ctx):
     """Log l'ouverture du classeur."""
-    workbook = context.get("workbook", {})
+    workbook = ctx.get("workbook", {})
     page_count = workbook.get("pageCount", 0)
     _log(f"Classeur chargé ({page_count} page(s)).")
 
 
-def on_page_enter(context):
+def on_page_enter(ctx):
     """Annoncer la page active."""
-    page = context.get("page", {})
+    page = ctx.get("page", {})
     _log(f"Ouverture de {page.get('name')}")
 
 

--- a/assets/scripts/pages/feuille_1.py
+++ b/assets/scripts/pages/feuille_1.py
@@ -1,15 +1,15 @@
 """Script de démonstration pour la feuille 1."""
 
 
-def on_page_enter(context):
+def on_page_enter(ctx):
     """Souhaite la bienvenue lorsque la page devient active."""
-    page = context.get("page", {})
+    page = ctx.get("page", {})
     print(f"[OptimaScript] Bienvenue sur {page.get('name')}")
 
 
-def on_cell_changed(context):
+def on_cell_changed(ctx):
     """Illustre la réception d'un événement de cellule."""
-    change = context.get("change", {})
-    label = context.get("cell", {}).get("label")
+    change = ctx.get("change", {})
+    label = ctx.get("cell", {}).get("label")
     new_value = change.get("newRaw")
     print(f"[OptimaScript] La cellule {label} vaut désormais {new_value!r}")

--- a/assets/scripts/pages/feuille_2.py
+++ b/assets/scripts/pages/feuille_2.py
@@ -1,9 +1,9 @@
 """Script de page simplifié pour Optima."""
+ 
 
-
-def on_page_enter(context):
+def on_page_enter(ctx):
     """Annonce la page courante dans les logs."""
-    page = context.get("page", {})
+    page = ctx.get("page", {})
     _log(f"Bienvenue sur {page.get('name')}")
 
 

--- a/assets/scripts/pages/menu_principal.py
+++ b/assets/scripts/pages/menu_principal.py
@@ -1,8 +1,8 @@
 """Script de la page de menu principal."""
 
 
-def on_page_enter(context):
-    page = context.get("page", {})
+def on_page_enter(ctx):
+    page = ctx.get("page", {})
     _log(f"Bienvenue sur {page.get('name')}")
 
 

--- a/assets/scripts/pages/notes_1.py
+++ b/assets/scripts/pages/notes_1.py
@@ -1,8 +1,8 @@
 """Script associé à une page de notes."""
 
 
-def on_page_enter(context):
-    page = context.get("page", {})
+def on_page_enter(ctx):
+    page = ctx.get("page", {})
     _log(f"Bienvenue sur {page.get('name')}")
 
 

--- a/assets/scripts/pages/notes_2.py
+++ b/assets/scripts/pages/notes_2.py
@@ -1,8 +1,8 @@
 """Deuxième script de notes pour Optima."""
 
 
-def on_page_enter(context):
-    page = context.get("page", {})
+def on_page_enter(ctx):
+    page = ctx.get("page", {})
     _log(f"Bienvenue sur {page.get('name')}")
 
 

--- a/assets/scripts/shared/default.py
+++ b/assets/scripts/shared/default.py
@@ -1,6 +1,8 @@
 """Utilitaires partagés pour les scripts Optima."""
 
 
-def helper(context, message: str = "Bonjour"):
+def helper(ctx, message: str = "Bonjour"):
     """Exemple de fonction réutilisable dans d'autres scripts."""
-    print(f"[OptimaScript] {message}")
+    page = ctx.get("page", {})
+    prefix = f"[{page.get('name')}] " if page else ""
+    print(f"[OptimaScript] {prefix}{message}")

--- a/lib/presentation/highlight/python_language.dart
+++ b/lib/presentation/highlight/python_language.dart
@@ -1,0 +1,110 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+import 'package:highlight/highlight.dart';
+import 'package:highlight/src/common_modes.dart';
+
+final python = Mode(
+    refs: {
+      '~contains~3~variants~2~contains~3': Mode(
+          className: "subst",
+          begin: "\\{",
+          end: "\\}",
+          keywords: {
+            "keyword":
+                "and elif is global as in if from raise for except finally print import pass return exec else break not with class assert yield try while continue del or def lambda async await nonlocal|10",
+            "built_in": "Ellipsis NotImplemented",
+            "literal": "False None True"
+          },
+          illegal: "#",
+          contains: [
+            Mode(ref: '~contains~3'),
+            Mode(ref: '~contains~1'),
+            Mode(ref: '~contains~0')
+          ]),
+      '~contains~3~variants~2~contains~2': Mode(begin: "\\{\\{", relevance: 0),
+      '~contains~3': Mode(className: "string", contains: [
+        BACKSLASH_ESCAPE
+      ], variants: [
+        Mode(
+            begin: "(u|b)?r?'''",
+            end: "'''",
+            contains: [BACKSLASH_ESCAPE, Mode(ref: '~contains~0')],
+            relevance: 10),
+        Mode(
+            begin: "(u|b)?r?\"\"\"",
+            end: "\"\"\"",
+            contains: [BACKSLASH_ESCAPE, Mode(ref: '~contains~0')],
+            relevance: 10),
+        Mode(begin: "(fr|rf|f)'''", end: "'''", contains: [
+          BACKSLASH_ESCAPE,
+          Mode(ref: '~contains~0'),
+          Mode(ref: '~contains~3~variants~2~contains~2'),
+          Mode(ref: '~contains~3~variants~2~contains~3')
+        ]),
+        Mode(begin: "(fr|rf|f)\"\"\"", end: "\"\"\"", contains: [
+          BACKSLASH_ESCAPE,
+          Mode(ref: '~contains~0'),
+          Mode(ref: '~contains~3~variants~2~contains~2'),
+          Mode(ref: '~contains~3~variants~2~contains~3')
+        ]),
+        Mode(begin: "(u|r|ur)'", end: "'", relevance: 10),
+        Mode(begin: "(u|r|ur)\"", end: "\"", relevance: 10),
+        Mode(begin: "(b|br)'", end: "'"),
+        Mode(begin: "(b|br)\"", end: "\""),
+        Mode(begin: "(fr|rf|f)'", end: "'", contains: [
+          BACKSLASH_ESCAPE,
+          Mode(ref: '~contains~3~variants~2~contains~2'),
+          Mode(ref: '~contains~3~variants~2~contains~3')
+        ]),
+        Mode(begin: "(fr|rf|f)\"", end: "\"", contains: [
+          BACKSLASH_ESCAPE,
+          Mode(ref: '~contains~3~variants~2~contains~2'),
+          Mode(ref: '~contains~3~variants~2~contains~3')
+        ]),
+        APOS_STRING_MODE,
+        QUOTE_STRING_MODE
+      ]),
+      '~contains~1': Mode(className: "number", relevance: 0, variants: [
+        Mode(begin: "\\b(0b[01]+)[lLjJ]?"),
+        Mode(begin: "\\b(0o[0-7]+)[lLjJ]?"),
+        Mode(
+            begin:
+                "(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)[lLjJ]?")
+      ]),
+      '~contains~0': Mode(className: "meta", begin: "^(>>>|\\.\\.\\.) "),
+    },
+    aliases: ["py", "gyp", "ipython"],
+    keywords: {
+      "keyword":
+          "and elif is global as in if from raise for except finally print import pass return exec else break not with class assert yield try while continue del or def lambda async await nonlocal|10",
+      "built_in": "Ellipsis NotImplemented",
+      "literal": "False None True"
+    },
+    illegal: "(<\\/|->|\\?)|=>",
+    contains: [
+      Mode(ref: '~contains~0'),
+      Mode(ref: '~contains~1'),
+      Mode(beginKeywords: "if", relevance: 0),
+      Mode(ref: '~contains~3'),
+      HASH_COMMENT_MODE,
+      Mode(
+          variants: [
+            Mode(className: "function", beginKeywords: "def"),
+            Mode(className: "class", beginKeywords: "class")
+          ],
+          end: ":",
+          illegal: "[\${=;\\n,]",
+          contains: [
+            UNDERSCORE_TITLE_MODE,
+            Mode(className: "params", begin: "\\(", end: "\\)", contains: [
+              Mode(self: true),
+              Mode(ref: '~contains~0'),
+              Mode(ref: '~contains~1'),
+              Mode(ref: '~contains~3'),
+              HASH_COMMENT_MODE
+            ]),
+            Mode(begin: "->", endsWithParent: true, keywords: "None")
+          ]),
+      Mode(className: "meta", begin: "^[\\t ]*@", end: "\$"),
+      Mode(begin: "\\b(print|exec)\\(")
+    ]);

--- a/lib/presentation/workbook_navigator/workbook_navigator.dart
+++ b/lib/presentation/workbook_navigator/workbook_navigator.dart
@@ -4,7 +4,9 @@ import 'package:code_text_field/code_text_field.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:highlight/languages/python.dart';
+import 'package:python_ffi_dart/python_ffi_dart.dart';
+
+import '../highlight/python_language.dart';
 
 import '../../application/commands/add_notes_page_command.dart';
 import '../../application/commands/add_sheet_command.dart';

--- a/scripts/global/default.py
+++ b/scripts/global/default.py
@@ -1,16 +1,16 @@
 """Script global d'exemple pour Optima."""
 
 
-def on_workbook_open(context):
+def on_workbook_open(ctx):
     """Log l'ouverture du classeur."""
-    workbook = context.get("workbook", {})
+    workbook = ctx.get("workbook", {})
     page_count = workbook.get("pageCount", 0)
     _log(f"Classeur chargé ({page_count} page(s)).")
 
 
-def on_page_enter(context):
+def on_page_enter(ctx):
     """Annoncer la page active."""
-    page = context.get("page", {})
+    page = ctx.get("page", {})
     _log(f"Ouverture de {page.get('name')}")
 
 

--- a/scripts/pages/feuille_1.py
+++ b/scripts/pages/feuille_1.py
@@ -1,16 +1,16 @@
 """Exemple de script de page pour Optima."""
 
 
-def on_page_enter(context):
+def on_page_enter(ctx):
     """Souhaite la bienvenue lorsque la page devient active."""
-    page = context.get("page", {})
+    page = ctx.get("page", {})
     _log(f"Bienvenue sur {page.get('name')}, test")
 
 
-def on_cell_changed(context):
+def on_cell_changed(ctx):
     """Illustration d'un traitement de modification de cellule."""
-    change = context.get("change", {})
-    cell = context.get("cell", {})
+    change = ctx.get("change", {})
+    cell = ctx.get("cell", {})
     label = cell.get("label")
     new_value = change.get("newRaw")
     _log(f"La cellule {label} vaut désormais {new_value!r}")

--- a/scripts/pages/feuille_2.py
+++ b/scripts/pages/feuille_2.py
@@ -1,9 +1,9 @@
 """Script de page simplifié pour Optima."""
 
 
-def on_page_enter(context):
+def on_page_enter(ctx):
     """Annonce la page courante dans les logs."""
-    page = context.get("page", {})
+    page = ctx.get("page", {})
     _log(f"Bienvenue sur {page.get('name')}")
 
 

--- a/scripts/pages/menu_principal.py
+++ b/scripts/pages/menu_principal.py
@@ -1,8 +1,8 @@
 """Script de la page de menu principal."""
 
 
-def on_page_enter(context):
-    page = context.get("page", {})
+def on_page_enter(ctx):
+    page = ctx.get("page", {})
     _log(f"Bienvenue sur {page.get('name')}")
 
 

--- a/scripts/pages/notes_1.py
+++ b/scripts/pages/notes_1.py
@@ -1,8 +1,8 @@
 """Script associé à une page de notes."""
 
 
-def on_page_enter(context):
-    page = context.get("page", {})
+def on_page_enter(ctx):
+    page = ctx.get("page", {})
     _log(f"Bienvenue sur {page.get('name')}")
 
 

--- a/scripts/pages/notes_2.py
+++ b/scripts/pages/notes_2.py
@@ -1,8 +1,8 @@
 """Deuxième script de notes pour Optima."""
 
 
-def on_page_enter(context):
-    page = context.get("page", {})
+def on_page_enter(ctx):
+    page = ctx.get("page", {})
     _log(f"Bienvenue sur {page.get('name')}")
 
 

--- a/scripts/shared/default.py
+++ b/scripts/shared/default.py
@@ -1,6 +1,8 @@
 """Utilitaires Python partagés pour Optima."""
 
 
-def helper(context, message: str = "Bonjour"):
+def helper(ctx, message: str = "Bonjour"):
     """Exemple de fonction réutilisable dans d'autres modules."""
-    print(f"[OptimaScript] {message}")
+    page = ctx.get("page", {})
+    prefix = f"[{page.get('name')}] " if page else ""
+    print(f"[OptimaScript] {prefix}{message}")


### PR DESCRIPTION
## Summary
- embed a local Python syntax definition and configure the script editor for 4-space indentation with updated insertion snippets
- validate scripts at save time through the PythonScriptEngine and extend default templates for Python lifecycle hooks
- migrate bundled and workspace scripts to Python modules that receive a ctx dictionary instead of YAML

## Testing
- not run (flutter CLI unavailable)

------
https://chatgpt.com/codex/tasks/task_e_68e1adeaea248326b041014434aeac44