### PR TITLE
Refactor script runtime callbacks for Dart engine integration

### DIFF
--- a/lib/application/scripts/dart/dart_script_engine.dart
+++ b/lib/application/scripts/dart/dart_script_engine.dart
@@ -42,17 +42,24 @@ class DartBindingHost {
   }
 }
 
+/// Signature for a compiled script callback.
+typedef DartScriptCallback = FutureOr<void> Function(ScriptContext context);
+
 /// Representation of a callable export defined by a script.
 class DartScriptExport {
   const DartScriptExport({
     required this.name,
-    required Future<void> Function(ScriptContext context) callback,
+    required DartScriptCallback callback,
   }) : _callback = callback;
 
   final String name;
-  final Future<void> Function(ScriptContext context) _callback;
+  final DartScriptCallback _callback;
 
-  Future<void> call(ScriptContext context) => _callback(context);
+  DartScriptCallback get callback => _callback;
+
+  Future<void> call(ScriptContext context) async {
+    await Future.sync(() => _callback(context));
+  }
 }
 
 /// Container for the compiled representation of a script.
@@ -131,7 +138,7 @@ class DartScriptEngine {
     );
   }
 
-  Future<void> Function(ScriptContext context) _compileCallback(
+  DartScriptCallback _compileCallback(
     String name,
     Object? definition,
   ) {

--- a/test/application/scripts/script_runtime_test.dart
+++ b/test/application/scripts/script_runtime_test.dart
@@ -1,0 +1,188 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_application_1/application/commands/workbook_command_manager.dart';
+import 'package:flutter_application_1/application/scripts/context.dart';
+import 'package:flutter_application_1/application/scripts/dart/dart_script_engine.dart';
+import 'package:flutter_application_1/application/scripts/models.dart';
+import 'package:flutter_application_1/application/scripts/runtime.dart';
+import 'package:flutter_application_1/application/scripts/storage.dart';
+import 'package:flutter_application_1/domain/sheet.dart';
+import 'package:flutter_application_1/domain/workbook.dart';
+
+class _InMemoryScriptStorage extends ScriptStorage {
+  _InMemoryScriptStorage({Map<String, StoredScript>? scripts})
+      : _scripts = Map<String, StoredScript>.from(scripts ?? <String, StoredScript>{}),
+        super(bundle: _FakeAssetBundle());
+
+  final Map<String, StoredScript> _scripts;
+  bool initializeCalled = false;
+  bool precompileRequested = false;
+
+  void addScript(StoredScript script) {
+    _scripts[_cacheKey(script.descriptor)] = script;
+  }
+
+  @override
+  Future<void> initialize({bool precompileAssets = false}) async {
+    initializeCalled = true;
+    precompileRequested = precompileAssets;
+  }
+
+  @override
+  Future<StoredScript?> loadScript(ScriptDescriptor descriptor) async {
+    return _scripts[_cacheKey(descriptor)];
+  }
+
+  static String _cacheKey(ScriptDescriptor descriptor) =>
+      '${descriptor.scope.name}:${descriptor.key}';
+}
+
+class _FakeAssetBundle extends CachingAssetBundle {}
+
+StoredScript _createStoredScript({
+  required ScriptDescriptor descriptor,
+  required Map<String, DartScriptCallback> callbacks,
+}) {
+  final exports = <String, DartScriptExport>{
+    for (final entry in callbacks.entries)
+      entry.key: DartScriptExport(name: entry.key, callback: entry.value),
+  };
+  final module = DartScriptModule(
+    descriptor: descriptor,
+    source: '{}',
+    exports: exports,
+  );
+  final document = ScriptDocument(
+    id: descriptor.key,
+    name: descriptor.key,
+    scope: descriptor.scope,
+    module: module,
+    exports: exports,
+  );
+  return StoredScript(
+    descriptor: descriptor,
+    source: '{}',
+    document: document,
+    origin: 'memory',
+    isMutable: false,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ScriptRuntime', () {
+    late Workbook workbook;
+    late WorkbookCommandManager commandManager;
+
+    setUp(() {
+      workbook = Workbook(
+        pages: <Sheet>[
+          Sheet.fromRows(name: 'Feuille', rows: const <List<Object?>>[<Object?>[null]]),
+        ],
+      );
+      commandManager = WorkbookCommandManager(initialWorkbook: workbook);
+    });
+
+    test('dispatches workbook open events to registered scripts', () async {
+      final storage = _InMemoryScriptStorage();
+      final descriptor = const ScriptDescriptor(scope: ScriptScope.global, key: 'default');
+      final calls = <String>[];
+      storage.addScript(
+        _createStoredScript(
+          descriptor: descriptor,
+          callbacks: <String, DartScriptCallback>{
+            'onWorkbookOpen': (ScriptContext context) {
+              calls.add(context.eventType.wireName);
+              return context.logMessage('log:${context.descriptor.key}');
+            },
+          },
+        ),
+      );
+
+      final logs = <String>[];
+      final runtime = ScriptRuntime(
+        storage: storage,
+        commandManager: commandManager,
+        logSink: (message) => logs.add(message),
+      );
+
+      await runtime.dispatchWorkbookOpen();
+
+      expect(storage.initializeCalled, isTrue);
+      expect(storage.precompileRequested, isTrue);
+      expect(calls, contains('workbook.open'));
+      expect(logs, contains('log:default'));
+    });
+
+    test('supports synchronous callbacks returning void', () async {
+      final storage = _InMemoryScriptStorage();
+      final descriptor = const ScriptDescriptor(scope: ScriptScope.global, key: 'default');
+      var invoked = false;
+      storage.addScript(
+        _createStoredScript(
+          descriptor: descriptor,
+          callbacks: <String, DartScriptCallback>{
+            'onWorkbookOpen': (ScriptContext context) {
+              invoked = true;
+            },
+          },
+        ),
+      );
+
+      final runtime = ScriptRuntime(
+        storage: storage,
+        commandManager: commandManager,
+      );
+
+      await runtime.dispatchWorkbookOpen();
+
+      expect(invoked, isTrue);
+    });
+
+    test('propagates errors thrown by callbacks with formatted logs', () async {
+      final storage = _InMemoryScriptStorage();
+      final descriptor = const ScriptDescriptor(scope: ScriptScope.global, key: 'default');
+      storage.addScript(
+        _createStoredScript(
+          descriptor: descriptor,
+          callbacks: <String, DartScriptCallback>{
+            'onWorkbookOpen': (ScriptContext context) {
+              throw StateError('boom');
+            },
+          },
+        ),
+      );
+
+      final logs = <String>[];
+      final runtime = ScriptRuntime(
+        storage: storage,
+        commandManager: commandManager,
+        logSink: (message) => logs.add(message),
+      );
+
+      final previousOnError = FlutterError.onError;
+      final captured = <FlutterErrorDetails>[];
+      FlutterError.onError = (details) => captured.add(details);
+      addTearDown(() {
+        FlutterError.onError = previousOnError;
+      });
+
+      await expectLater(
+        runtime.dispatchWorkbookOpen(),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(logs, isNotEmpty);
+      expect(logs.first, contains('Erreur script détectée'));
+      expect(logs.first, contains('Callback : onWorkbookOpen'));
+      expect(logs.first, contains('Exception: StateError: boom'));
+      expect(captured, isNotEmpty);
+      expect(captured.first.exception, isA<StateError>());
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- update script exports to use the new Dart callback abstractions and support synchronous callbacks
- warm up the Dart script engine during runtime initialisation and improve error logging
- add integration-style runtime tests covering event dispatch and error propagation

## Testing
- Not run (Flutter and Dart tooling are unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e25fcca73483269fec0f929c4c83fb