### PR TITLE
Fix fake asset bundle for script storage tests

### DIFF
--- a/test/application/scripts/script_storage_migration_test.dart
+++ b/test/application/scripts/script_storage_migration_test.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -15,6 +17,26 @@ class _FakeAssetBundle extends CachingAssetBundle {
   final Map<String, String> _assets;
 
   @override
+  Future<ByteData> load(String key, {bool cache = true}) async {
+    if (key == 'AssetManifest.json') {
+      final bytes = Uint8List.fromList(utf8.encode(_manifest));
+      return ByteData.view(bytes.buffer);
+    }
+    final asset = _assets[key];
+    if (asset != null) {
+      final bytes = Uint8List.fromList(utf8.encode(asset));
+      return ByteData.view(bytes.buffer);
+    }
+    throw FlutterError('Unable to load asset: $key');
+  }
+
+  @override
+  Future<ByteBuffer> loadBuffer(String key, {bool cache = true}) async {
+    final data = await load(key, cache: cache);
+    return data.buffer;
+  }
+
+  @override
   Future<String> loadString(String key, {bool cache = true}) async {
     if (key == 'AssetManifest.json') {
       return _manifest;
@@ -23,7 +45,7 @@ class _FakeAssetBundle extends CachingAssetBundle {
     if (asset != null) {
       return asset;
     }
-    throw FlutterError('Asset $key introuvable');
+    throw FlutterError('Unable to load asset: $key');
   }
 }
 


### PR DESCRIPTION
## Summary
- import the typed data and foundation libraries for the script storage migration test
- extend the fake asset bundle to return empty ByteData for manifest and asset requests
- ensure missing assets throw FlutterError consistently

## Testing
- (not run)

------
https://chatgpt.com/codex/tasks/task_e_68e26353bf7c8326b62b551d6ea9cdda