### PR TITLE
Add signatures metadata for Dart scripts

### DIFF
--- a/lib/application/scripts/models.dart
+++ b/lib/application/scripts/models.dart
@@ -15,6 +15,7 @@ class ScriptDocument {
     required this.scope,
     required this.module,
     required this.exports,
+    required this.signatures,
   });
 
   final String id;
@@ -22,14 +23,20 @@ class ScriptDocument {
   final ScriptScope scope;
   final DartScriptModule module;
   final Map<String, DartScriptExport> exports;
+  final Map<String, DartScriptSignature> signatures;
 
   Iterable<String> get exportNames => exports.keys;
 
+  Iterable<String> get signatureNames => signatures.keys;
+
   DartScriptExport? operator [](String name) => exports[name];
+
+  DartScriptSignature? signatureFor(String name) => signatures[name];
 
   ScriptDocument copyWith({
     DartScriptModule? module,
     Map<String, DartScriptExport>? exports,
+    Map<String, DartScriptSignature>? signatures,
   }) {
     return ScriptDocument(
       id: id,
@@ -37,6 +44,7 @@ class ScriptDocument {
       scope: scope,
       module: module ?? this.module,
       exports: exports ?? this.exports,
+      signatures: signatures ?? this.signatures,
     );
   }
 }

--- a/lib/application/scripts/runtime.dart
+++ b/lib/application/scripts/runtime.dart
@@ -189,7 +189,7 @@ class ScriptRuntime {
     ScriptContext context,
   ) async {
     final callbackName = _callbackName(type);
-    final export = script.document[callbackName];
+    final export = script.export(callbackName);
     if (export == null) {
       return;
     }

--- a/lib/application/scripts/storage.dart
+++ b/lib/application/scripts/storage.dart
@@ -23,6 +23,18 @@ class StoredScript {
   final String origin;
   final bool isMutable;
 
+  Iterable<String> get exportNames => document.exportNames;
+
+  DartScriptExport? export(String name) => document[name];
+
+  Map<String, DartScriptExport> get exports => document.exports;
+
+  Map<String, DartScriptSignature> get signatures => document.signatures;
+
+  DartScriptSignature? signatureFor(String name) => document.signatureFor(name);
+
+  Iterable<String> get signatureNames => document.signatureNames;
+
   StoredScript copyWith({
     String? source,
     ScriptDocument? document,
@@ -389,6 +401,7 @@ class ScriptStorage {
 
     DartScriptModule module;
     Map<String, DartScriptExport> exports;
+    Map<String, DartScriptSignature> signatures;
 
     try {
       module = await _engine.loadModule(
@@ -396,6 +409,7 @@ class ScriptStorage {
         source: source,
       );
       exports = Map<String, DartScriptExport>.from(module.exports);
+      signatures = Map<String, DartScriptSignature>.from(module.signatures);
     } on DartScriptCompilationException catch (error, stackTrace) {
       debugPrint(
         'Erreur lors de l\'analyse du module ${descriptor.fileName}: $error\n$stackTrace',
@@ -407,8 +421,10 @@ class ScriptStorage {
         descriptor: descriptor,
         source: source,
         exports: const <String, DartScriptExport>{},
+        signatures: const <String, DartScriptSignature>{},
       );
       exports = const <String, DartScriptExport>{};
+      signatures = const <String, DartScriptSignature>{};
     } catch (error, stackTrace) {
       debugPrint(
         'Erreur inattendue lors du chargement du module ${descriptor.fileName}: '
@@ -424,8 +440,10 @@ class ScriptStorage {
         descriptor: descriptor,
         source: source,
         exports: const <String, DartScriptExport>{},
+        signatures: const <String, DartScriptSignature>{},
       );
       exports = const <String, DartScriptExport>{};
+      signatures = const <String, DartScriptSignature>{};
     }
 
     final document = ScriptDocument(
@@ -434,6 +452,7 @@ class ScriptStorage {
       scope: descriptor.scope,
       module: module,
       exports: exports,
+      signatures: signatures,
     );
     _documentCache[cacheKey] = _CachedDocument(
       signature: signature,

--- a/test/application/scripts/dart_script_engine_test.dart
+++ b/test/application/scripts/dart_script_engine_test.dart
@@ -43,6 +43,9 @@ void main() {
       );
 
       expect(module.exportNames, contains('onWorkbookOpen'));
+      final signature = module.signatureFor('onWorkbookOpen');
+      expect(signature, isNotNull);
+      expect(signature!.hostFunctions, containsAll(<String>['capture']));
       final export = module['onWorkbookOpen'];
       expect(export, isNotNull);
 

--- a/test/application/scripts/script_runtime_test.dart
+++ b/test/application/scripts/script_runtime_test.dart
@@ -62,10 +62,15 @@ StoredScript _createStoredScript({
     for (final entry in callbacks.entries)
       entry.key: DartScriptExport(name: entry.key, callback: entry.value),
   };
+  final signatures = <String, DartScriptSignature>{
+    for (final name in callbacks.keys)
+      name: DartScriptSignature(),
+  };
   final module = DartScriptModule(
     descriptor: descriptor,
     source: '{}',
     exports: exports,
+    signatures: signatures,
   );
   final document = ScriptDocument(
     id: descriptor.key,
@@ -73,6 +78,7 @@ StoredScript _createStoredScript({
     scope: descriptor.scope,
     module: module,
     exports: exports,
+    signatures: signatures,
   );
   return StoredScript(
     descriptor: descriptor,


### PR DESCRIPTION
## Summary
- add Dart-side signature metadata for script modules to describe host function usage
- surface the new metadata through storage/runtime helpers and switch runtime to the new getters
- update script engine and runtime tests to cover the Dart signature capabilities

## Testing
- Not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2657bf35c83268e12b627dfdd499c