### PR TITLE
Clean up runtime initialization and add Dart script dependency

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,11 +47,7 @@ class _MyAppState extends State<MyApp> {
       storage: storage,
       commandManager: _commandManager,
     );
-    unawaited(
-      _scriptRuntime.initialize().then(
-        (_) => _scriptRuntime.dispatchWorkbookOpen(),
-      ),
-    );
+    unawaited(_initialiseScripts());
   }
 
   @override
@@ -60,6 +56,11 @@ class _MyAppState extends State<MyApp> {
     unawaited(_scriptRuntime.dispatchWorkbookClose());
     _commandManager.dispose();
     super.dispose();
+  }
+
+  Future<void> _initialiseScripts() async {
+    await _scriptRuntime.initialize();
+    await _scriptRuntime.dispatchWorkbookOpen();
   }
 
   void _updateMode(AppMode mode) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   path: ^1.9.0
   code_text_field: ^1.1.0
   highlight: ^0.7.0
+  dart_eval: ^0.7.10
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add the dart_eval dependency to the project to replace the removed Python runtime tooling
- refactor runtime bootstrap in MyApp so scripts initialize before dispatching the workbook open event

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e26cfd7a408326bdc6c32f2c6807b1