### PR TITLE
Fix const usage for api stub source

### DIFF
--- a/lib/application/scripts/dart/dart_script_engine.dart
+++ b/lib/application/scripts/dart/dart_script_engine.dart
@@ -137,7 +137,7 @@ class DartScriptEngine {
     final plugin = _OptimaScriptPlugin(_bindingHost);
     compiler.addPlugin(plugin);
     compiler.entrypoints.add(libraryUri);
-    compiler.addSource(const DartSource(_apiLibraryUri, _apiStub));
+    compiler.addSource(DartSource(_apiLibraryUri, _apiStub));
 
     Program program;
     try {


### PR DESCRIPTION
## Summary
- remove the const constructor invocation when adding the API stub source to the compiler

## Testing
- dart analyze *(fails: `dart` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2820e60a88326b4b89377a5d79089