### PR TITLE
Fix ScriptContext bridge type declaration

### DIFF
--- a/lib/application/scripts/dart/dart_script_engine.dart
+++ b/lib/application/scripts/dart/dart_script_engine.dart
@@ -276,7 +276,7 @@ class $ScriptContext
   $ScriptContext.wrap(this.$value, this._bindingHost)
       : _superclass = $Object($value);
 
-  static final $type = BridgeTypeSpec(_apiLibraryUri, 'ScriptContext').ref;
+  static const $type = BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'ScriptContext'));
 
   static final $declaration = BridgeClassDef(
     BridgeClassType($type, isAbstract: true),


### PR DESCRIPTION
## Summary
- construct the ScriptContext bridge type using BridgeTypeRef and BridgeTypeSpec directly to match runtime lookups

## Testing
- dart analyze *(fails: dart not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2826e012c8326a1e668c9563ba3a1