### PR TITLE
Fix script API imports

### DIFF
--- a/lib/application/scripts/api/api.dart
+++ b/lib/application/scripts/api/api.dart
@@ -3,10 +3,10 @@ import '../../commands/insert_column_command.dart';
 import '../../commands/insert_row_command.dart';
 import '../../commands/set_cell_value_command.dart';
 import '../../commands/workbook_command_manager.dart';
-import '../../domain/cell.dart';
-import '../../domain/sheet.dart';
-import '../../domain/workbook.dart';
-import '../../state/sheet_selection_state.dart';
+import '../../../domain/cell.dart';
+import '../../../domain/sheet.dart';
+import '../../../domain/workbook.dart';
+import '../../../state/sheet_selection_state.dart';
 
 /// Point d'accès racine vers les APIs scripts.
 class ScriptApi {


### PR DESCRIPTION
## Summary
- update the script API imports so they target the domain and state modules via three-level relative paths

## Testing
- flutter analyze *(fails: `flutter` command not available in environment)*
- dart analyze *(fails: `dart` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28fb3a0408326a7f2dc8f4fd09085