### PR TITLE
docs: clarify Dart script engine role

### DIFF
--- a/lib/application/scripts/dart/dart_script_engine.dart
+++ b/lib/application/scripts/dart/dart_script_engine.dart
@@ -113,7 +113,11 @@ class DartScriptCompilationException implements Exception {
   String toString() => message;
 }
 
-/// Interpreter for OptimaScript modules written in a declarative JSON DSL.
+/// Loader and compiler for OptimaScript Dart modules executed through
+/// `dart_eval`, responsible for preparing the runtime.
+///
+/// Injects the `optimascript/api.dart` stub and registers the supported
+/// callbacks so that the host environment and scripts share the same contract.
 class DartScriptEngine {
   const DartScriptEngine({DartBindingHost? bindingHost})
       : _bindingHost = bindingHost ?? DartBindingHost.empty;


### PR DESCRIPTION
## Summary
- update the Dart script engine documentation comment to describe its role compiling OptimaScript Dart modules via dart_eval
- note that the engine injects the optimascript/api.dart stub and exposes supported callbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a08ba2b883268c4077c49c9c1465