### PR TITLE
Add range scripting APIs and commands

### DIFF
--- a/docs/optimascript-migration.md
+++ b/docs/optimascript-migration.md
@@ -33,9 +33,28 @@ sur le moteur de commandes existant.
 | `workbook.sheetByName(name)` / `sheetAt(index)` | Résolution explicite d'une feuille. |
 | `workbook.activateSheetByName(name)` | Active une feuille et déclenche la navigation. |
 | `sheet.cellAt(row, column)` / `cellByLabel('A1')` | Accès typé aux cellules. |
+| `sheet.range('A1:C5')` | Retourne un `RangeApi` chaînable pour lire/écrire une plage rectangulaire. |
+| `sheet.row(index)` / `sheet.column(index)` | Wrappers dédiés pour manipuler rapidement une ligne ou une colonne. |
 | `cell.setValue(value)` / `cell.clear()` | Écritures atomiques sur les cellules. |
 | `sheet.insertRow([index])` / `sheet.insertColumn([index])` | Insertion structurée dans la grille. |
 | `sheet.clear()` | Réinitialise l'ensemble d'une feuille. |
+
+### `RangeApi`, `RowApi`, `ColumnApi` et `ChartApi`
+
+Les nouvelles primitives exposent une ergonomie proche de celle d'Excel/Google Sheets :
+
+* `RangeApi` permet de récupérer les valeurs via `range.values`, d'appliquer des blocs avec
+  `range.setValues([...])`, de réaliser un remplissage automatique (`fillDown`/`fillRight`),
+  de trier (`sortByColumn`), de normaliser les nombres (`formatAsNumber`) ou encore de
+  nettoyer les textes (`autoFit`). Chaque méthode retourne la même instance pour favoriser
+  les chaînages (`range.setValues(...).formatAsNumber(2).autoFit()`).
+* `RowApi` et `ColumnApi` simplifient les écritures unitaires (`setValues`), le
+  formatage numérique et le remplissage horizontal/vertical.
+* `ChartApi` encapsule la plage source d'un graphique fictif. Il est possible de consulter
+  les métadonnées via `chart.describe()` ou de mettre à jour la plage avec `chart.updateRange(...)`.
+
+Toutes ces opérations s'appuient sur le moteur de commandes existant, garantissant un
+historique cohérent et la synchronisation avec l'interface utilisateur.
 
 ### Nouveaux événements VBA pris en charge
 

--- a/lib/application/commands/auto_fill_range_command.dart
+++ b/lib/application/commands/auto_fill_range_command.dart
@@ -1,0 +1,133 @@
+import '../../domain/cell.dart';
+import '../../domain/sheet.dart';
+import '../../domain/workbook.dart';
+import 'command_utils.dart';
+import 'workbook_command.dart';
+
+enum RangeFillDirection { down, right }
+
+/// Commande permettant de recopier automatiquement des valeurs sur une plage.
+class AutoFillRangeCommand extends WorkbookCommand {
+  AutoFillRangeCommand({
+    required this.sheetName,
+    required this.startRow,
+    required this.startColumn,
+    required this.rowCount,
+    required this.columnCount,
+    this.direction = RangeFillDirection.down,
+  })  : assert(rowCount > 0, 'rowCount must be > 0'),
+        assert(columnCount > 0, 'columnCount must be > 0');
+
+  final String sheetName;
+  final int startRow;
+  final int startColumn;
+  final int rowCount;
+  final int columnCount;
+  final RangeFillDirection direction;
+
+  @override
+  String get label => 'Remplissage automatique';
+
+  @override
+  bool canExecute(WorkbookCommandContext context) {
+    if (startRow < 0 || startColumn < 0) {
+      return false;
+    }
+    final sheet = _resolveSheet(context.workbook);
+    if (sheet == null) {
+      return false;
+    }
+    if (startRow + rowCount > sheet.rowCount) {
+      return false;
+    }
+    if (startColumn + columnCount > sheet.columnCount) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
+    final sheet = _resolveSheet(context.workbook);
+    if (sheet == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+    final pageIndex = context.pageIndexOf(sheet);
+    if (pageIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    final rows = cloneSheetRows(sheet);
+    var changed = false;
+
+    switch (direction) {
+      case RangeFillDirection.down:
+        for (var c = 0; c < columnCount; c++) {
+          final template = rows[startRow][startColumn + c];
+          for (var r = 1; r < rowCount; r++) {
+            final targetRow = startRow + r;
+            final current = rows[targetRow][startColumn + c];
+            if (current.type == template.type && current.value == template.value) {
+              continue;
+            }
+            rows[targetRow][startColumn + c] = Cell(
+              row: targetRow,
+              column: startColumn + c,
+              type: template.type,
+              value: template.value,
+            );
+            changed = true;
+          }
+        }
+        break;
+      case RangeFillDirection.right:
+        for (var r = 0; r < rowCount; r++) {
+          final template = rows[startRow + r][startColumn];
+          for (var c = 1; c < columnCount; c++) {
+            final targetColumn = startColumn + c;
+            final current = rows[startRow + r][targetColumn];
+            if (current.type == template.type && current.value == template.value) {
+              continue;
+            }
+            rows[startRow + r][targetColumn] = Cell(
+              row: startRow + r,
+              column: targetColumn,
+              type: template.type,
+              value: template.value,
+            );
+            changed = true;
+          }
+        }
+        break;
+    }
+
+    if (!changed) {
+      return WorkbookCommandResult(
+        workbook: context.workbook,
+        activePageIndex: context.activePageIndex,
+      );
+    }
+
+    final normalisedRows = normaliseCellCoordinates(rows);
+    final updatedSheet = rebuildSheetFromRows(sheet, normalisedRows);
+    final workbook = replaceSheetAtPageIndex(
+      context.workbook,
+      pageIndex,
+      updatedSheet,
+    );
+
+    return WorkbookCommandResult(
+      workbook: workbook,
+      activePageIndex: context.activePageIndex,
+    );
+  }
+
+  Sheet? _resolveSheet(Workbook workbook) {
+    for (final sheet in workbook.sheets) {
+      if (sheet.name == sheetName) {
+        return sheet;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/application/commands/auto_fit_range_command.dart
+++ b/lib/application/commands/auto_fit_range_command.dart
@@ -1,0 +1,111 @@
+import '../../domain/cell.dart';
+import '../../domain/sheet.dart';
+import '../../domain/workbook.dart';
+import 'command_utils.dart';
+import 'workbook_command.dart';
+
+/// Commande simulant un auto-fit en nettoyant les contenus textuels d'une plage.
+class AutoFitRangeCommand extends WorkbookCommand {
+  AutoFitRangeCommand({
+    required this.sheetName,
+    required this.startRow,
+    required this.startColumn,
+    required this.rowCount,
+    required this.columnCount,
+  })  : assert(rowCount > 0, 'rowCount must be > 0'),
+        assert(columnCount > 0, 'columnCount must be > 0');
+
+  final String sheetName;
+  final int startRow;
+  final int startColumn;
+  final int rowCount;
+  final int columnCount;
+
+  @override
+  String get label => 'Auto-fit plage';
+
+  @override
+  bool canExecute(WorkbookCommandContext context) {
+    if (startRow < 0 || startColumn < 0) {
+      return false;
+    }
+    final sheet = _resolveSheet(context.workbook);
+    if (sheet == null) {
+      return false;
+    }
+    if (startRow + rowCount > sheet.rowCount) {
+      return false;
+    }
+    if (startColumn + columnCount > sheet.columnCount) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
+    final sheet = _resolveSheet(context.workbook);
+    if (sheet == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+    final pageIndex = context.pageIndexOf(sheet);
+    if (pageIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    final rows = cloneSheetRows(sheet);
+    var changed = false;
+    for (var r = 0; r < rowCount; r++) {
+      for (var c = 0; c < columnCount; c++) {
+        final targetRow = startRow + r;
+        final targetColumn = startColumn + c;
+        final current = rows[targetRow][targetColumn];
+        if (current.type != CellType.text) {
+          continue;
+        }
+        final trimmed = current.value?.toString().trim();
+        if (trimmed == current.value) {
+          continue;
+        }
+        rows[targetRow][targetColumn] = Cell(
+          row: targetRow,
+          column: targetColumn,
+          type: trimmed == null || trimmed.isEmpty
+              ? CellType.empty
+              : CellType.text,
+          value: trimmed == null || trimmed.isEmpty ? null : trimmed,
+        );
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      return WorkbookCommandResult(
+        workbook: context.workbook,
+        activePageIndex: context.activePageIndex,
+      );
+    }
+
+    final normalisedRows = normaliseCellCoordinates(rows);
+    final updatedSheet = rebuildSheetFromRows(sheet, normalisedRows);
+    final workbook = replaceSheetAtPageIndex(
+      context.workbook,
+      pageIndex,
+      updatedSheet,
+    );
+
+    return WorkbookCommandResult(
+      workbook: workbook,
+      activePageIndex: context.activePageIndex,
+    );
+  }
+
+  Sheet? _resolveSheet(Workbook workbook) {
+    for (final sheet in workbook.sheets) {
+      if (sheet.name == sheetName) {
+        return sheet;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/application/commands/format_range_as_number_command.dart
+++ b/lib/application/commands/format_range_as_number_command.dart
@@ -1,0 +1,133 @@
+import '../../domain/cell.dart';
+import '../../domain/sheet.dart';
+import '../../domain/workbook.dart';
+import 'command_utils.dart';
+import 'workbook_command.dart';
+
+/// Commande appliquant un format numérique à une plage.
+class FormatRangeAsNumberCommand extends WorkbookCommand {
+  FormatRangeAsNumberCommand({
+    required this.sheetName,
+    required this.startRow,
+    required this.startColumn,
+    required this.rowCount,
+    required this.columnCount,
+    this.decimalDigits,
+  })  : assert(rowCount > 0, 'rowCount must be > 0'),
+        assert(columnCount > 0, 'columnCount must be > 0'),
+        assert(decimalDigits == null || decimalDigits >= 0,
+            'decimalDigits must be >= 0');
+
+  final String sheetName;
+  final int startRow;
+  final int startColumn;
+  final int rowCount;
+  final int columnCount;
+  final int? decimalDigits;
+
+  @override
+  String get label => 'Format numérique de plage';
+
+  @override
+  bool canExecute(WorkbookCommandContext context) {
+    if (startRow < 0 || startColumn < 0) {
+      return false;
+    }
+    final sheet = _resolveSheet(context.workbook);
+    if (sheet == null) {
+      return false;
+    }
+    if (startRow + rowCount > sheet.rowCount) {
+      return false;
+    }
+    if (startColumn + columnCount > sheet.columnCount) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
+    final sheet = _resolveSheet(context.workbook);
+    if (sheet == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+    final pageIndex = context.pageIndexOf(sheet);
+    if (pageIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    final rows = cloneSheetRows(sheet);
+    var changed = false;
+    for (var r = 0; r < rowCount; r++) {
+      for (var c = 0; c < columnCount; c++) {
+        final targetRow = startRow + r;
+        final targetColumn = startColumn + c;
+        final current = rows[targetRow][targetColumn];
+        final formatted = _formatCell(targetRow, targetColumn, current);
+        if (formatted == null) {
+          continue;
+        }
+        if (current.type == formatted.type && current.value == formatted.value) {
+          continue;
+        }
+        rows[targetRow][targetColumn] = formatted;
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      return WorkbookCommandResult(
+        workbook: context.workbook,
+        activePageIndex: context.activePageIndex,
+      );
+    }
+
+    final normalisedRows = normaliseCellCoordinates(rows);
+    final updatedSheet = rebuildSheetFromRows(sheet, normalisedRows);
+    final workbook = replaceSheetAtPageIndex(
+      context.workbook,
+      pageIndex,
+      updatedSheet,
+    );
+
+    return WorkbookCommandResult(
+      workbook: workbook,
+      activePageIndex: context.activePageIndex,
+    );
+  }
+
+  Cell? _formatCell(int row, int column, Cell current) {
+    if (current.type == CellType.empty) {
+      return null;
+    }
+    final asNumber = switch (current.type) {
+      CellType.number => current.value as num,
+      CellType.text => num.tryParse(current.value.toString()),
+      CellType.boolean => null,
+      CellType.empty => null,
+    };
+    if (asNumber == null) {
+      return null;
+    }
+
+    final num value;
+    if (decimalDigits != null) {
+      final precision = decimalDigits!.clamp(0, 15);
+      value = num.parse(asNumber.toStringAsFixed(precision));
+    } else {
+      value = asNumber;
+    }
+
+    return Cell(row: row, column: column, type: CellType.number, value: value);
+  }
+
+  Sheet? _resolveSheet(Workbook workbook) {
+    for (final sheet in workbook.sheets) {
+      if (sheet.name == sheetName) {
+        return sheet;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/application/commands/set_range_values_command.dart
+++ b/lib/application/commands/set_range_values_command.dart
@@ -1,0 +1,118 @@
+import '../../domain/cell.dart';
+import '../../domain/sheet.dart';
+import '../../domain/workbook.dart';
+import 'command_utils.dart';
+import 'workbook_command.dart';
+
+/// Commande permettant d'écrire un bloc de valeurs dans une plage rectangulaire.
+class SetRangeValuesCommand extends WorkbookCommand {
+  SetRangeValuesCommand({
+    required this.sheetName,
+    required this.startRow,
+    required this.startColumn,
+    required this.values,
+  }) : assert(values.isNotEmpty, 'values must not be empty'),
+        assert(values.every((row) => row.length == values.first.length),
+            'All value rows must share the same length.');
+
+  /// Nom de la feuille ciblée.
+  final String sheetName;
+
+  /// Index de ligne de départ (base zéro).
+  final int startRow;
+
+  /// Index de colonne de départ (base zéro).
+  final int startColumn;
+
+  /// Valeurs à appliquer.
+  final List<List<Object?>> values;
+
+  int get rowCount => values.length;
+  int get columnCount => values.first.length;
+
+  @override
+  String get label => 'Mettre à jour une plage';
+
+  @override
+  bool canExecute(WorkbookCommandContext context) {
+    if (startRow < 0 || startColumn < 0) {
+      return false;
+    }
+    final sheet = _resolveSheet(context.workbook);
+    if (sheet == null) {
+      return false;
+    }
+    if (startRow + rowCount > sheet.rowCount) {
+      return false;
+    }
+    if (startColumn + columnCount > sheet.columnCount) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
+    final sheet = _resolveSheet(context.workbook);
+    if (sheet == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    final pageIndex = context.pageIndexOf(sheet);
+    if (pageIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    final rows = cloneSheetRows(sheet);
+    var changed = false;
+    for (var r = 0; r < rowCount; r++) {
+      for (var c = 0; c < columnCount; c++) {
+        final targetRow = startRow + r;
+        final targetColumn = startColumn + c;
+        final newCell = _buildCell(targetRow, targetColumn, values[r][c]);
+        final current = rows[targetRow][targetColumn];
+        if (current.type == newCell.type && current.value == newCell.value) {
+          continue;
+        }
+        rows[targetRow][targetColumn] = newCell;
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      return WorkbookCommandResult(
+        workbook: context.workbook,
+        activePageIndex: context.activePageIndex,
+      );
+    }
+
+    final normalisedRows = normaliseCellCoordinates(rows);
+    final updatedSheet = rebuildSheetFromRows(sheet, normalisedRows);
+    final workbook = replaceSheetAtPageIndex(
+      context.workbook,
+      pageIndex,
+      updatedSheet,
+    );
+
+    return WorkbookCommandResult(
+      workbook: workbook,
+      activePageIndex: context.activePageIndex,
+    );
+  }
+
+  Sheet? _resolveSheet(Workbook workbook) {
+    for (final sheet in workbook.sheets) {
+      if (sheet.name == sheetName) {
+        return sheet;
+      }
+    }
+    return null;
+  }
+
+  Cell _buildCell(int row, int column, Object? value) {
+    if (value == null || (value is String && value.isEmpty)) {
+      return Cell(row: row, column: column, type: CellType.empty, value: null);
+    }
+    return Cell.fromValue(row: row, column: column, value: value);
+  }
+}

--- a/lib/application/commands/sort_range_command.dart
+++ b/lib/application/commands/sort_range_command.dart
@@ -1,0 +1,151 @@
+import '../../domain/cell.dart';
+import '../../domain/sheet.dart';
+import '../../domain/workbook.dart';
+import 'command_utils.dart';
+import 'workbook_command.dart';
+
+/// Commande triant les lignes d'une plage suivant une colonne de référence.
+class SortRangeCommand extends WorkbookCommand {
+  SortRangeCommand({
+    required this.sheetName,
+    required this.startRow,
+    required this.startColumn,
+    required this.rowCount,
+    required this.columnCount,
+    this.columnOffset = 0,
+    this.ascending = true,
+  })  : assert(rowCount > 0, 'rowCount must be > 0'),
+        assert(columnCount > 0, 'columnCount must be > 0'),
+        assert(columnOffset >= 0, 'columnOffset must be >= 0');
+
+  final String sheetName;
+  final int startRow;
+  final int startColumn;
+  final int rowCount;
+  final int columnCount;
+  final int columnOffset;
+  final bool ascending;
+
+  @override
+  String get label => 'Tri de plage';
+
+  @override
+  bool canExecute(WorkbookCommandContext context) {
+    if (startRow < 0 || startColumn < 0) {
+      return false;
+    }
+    final sheet = _resolveSheet(context.workbook);
+    if (sheet == null) {
+      return false;
+    }
+    if (startRow + rowCount > sheet.rowCount) {
+      return false;
+    }
+    if (startColumn + columnCount > sheet.columnCount) {
+      return false;
+    }
+    if (columnOffset >= columnCount) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  WorkbookCommandResult performExecute(WorkbookCommandContext context) {
+    final sheet = _resolveSheet(context.workbook);
+    if (sheet == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+    final pageIndex = context.pageIndexOf(sheet);
+    if (pageIndex == null) {
+      return WorkbookCommandResult(workbook: context.workbook);
+    }
+
+    final rows = cloneSheetRows(sheet);
+    final segment = <List<Cell>>[for (var r = 0; r < rowCount; r++) []];
+
+    for (var r = 0; r < rowCount; r++) {
+      for (var c = 0; c < columnCount; c++) {
+        segment[r].add(rows[startRow + r][startColumn + c]);
+      }
+    }
+
+    final sorted = List<List<Cell>>.from(segment);
+    sorted.sort((a, b) {
+      final left = a[columnOffset];
+      final right = b[columnOffset];
+      final order = _compareCells(left, right);
+      return ascending ? order : -order;
+    });
+
+    var changed = false;
+    for (var r = 0; r < rowCount; r++) {
+      for (var c = 0; c < columnCount; c++) {
+        final targetRow = startRow + r;
+        final targetColumn = startColumn + c;
+        final current = rows[targetRow][targetColumn];
+        final next = sorted[r][c];
+        if (current.type == next.type && current.value == next.value) {
+          continue;
+        }
+        rows[targetRow][targetColumn] = Cell(
+          row: targetRow,
+          column: targetColumn,
+          type: next.type,
+          value: next.value,
+        );
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      return WorkbookCommandResult(
+        workbook: context.workbook,
+        activePageIndex: context.activePageIndex,
+      );
+    }
+
+    final normalisedRows = normaliseCellCoordinates(rows);
+    final updatedSheet = rebuildSheetFromRows(sheet, normalisedRows);
+    final workbook = replaceSheetAtPageIndex(
+      context.workbook,
+      pageIndex,
+      updatedSheet,
+    );
+
+    return WorkbookCommandResult(
+      workbook: workbook,
+      activePageIndex: context.activePageIndex,
+    );
+  }
+
+  int _compareCells(Cell left, Cell right) {
+    if (left.type == CellType.empty && right.type == CellType.empty) {
+      return 0;
+    }
+    if (left.type == CellType.empty) {
+      return 1;
+    }
+    if (right.type == CellType.empty) {
+      return -1;
+    }
+    if (left.type == CellType.number && right.type == CellType.number) {
+      final lv = (left.value as num).toDouble();
+      final rv = (right.value as num).toDouble();
+      return lv.compareTo(rv);
+    }
+    if (left.type == CellType.boolean && right.type == CellType.boolean) {
+      return (left.value as bool).toString().compareTo((right.value as bool).toString());
+    }
+    return left.value.toString().compareTo(right.value.toString());
+  }
+
+  Sheet? _resolveSheet(Workbook workbook) {
+    for (final sheet in workbook.sheets) {
+      if (sheet.name == sheetName) {
+        return sheet;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/application/scripts/api/api.dart
+++ b/lib/application/scripts/api/api.dart
@@ -1,7 +1,12 @@
+import '../../commands/auto_fill_range_command.dart';
+import '../../commands/auto_fit_range_command.dart';
 import '../../commands/clear_sheet_command.dart';
+import '../../commands/format_range_as_number_command.dart';
 import '../../commands/insert_column_command.dart';
 import '../../commands/insert_row_command.dart';
 import '../../commands/set_cell_value_command.dart';
+import '../../commands/set_range_values_command.dart';
+import '../../commands/sort_range_command.dart';
 import '../../commands/workbook_command_manager.dart';
 import '../../../domain/cell.dart';
 import '../../../domain/sheet.dart';
@@ -195,6 +200,67 @@ class SheetApi {
     });
   }
 
+  /// Retourne un wrapper sur une plage rectangulaire.
+  RangeApi? range(String reference) {
+    final sheet = _resolveSheet();
+    final coordinates = _RangeReferenceParser(sheet).parse(reference);
+    if (coordinates == null) {
+      return null;
+    }
+    return RangeApi._(
+      commandManager: _commandManager,
+      sheetName: sheet.name,
+      coordinates: coordinates,
+    );
+  }
+
+  /// Retourne un wrapper sur une ligne (index 0-based).
+  RowApi? row(int index) {
+    final sheet = _resolveSheet();
+    if (index < 0 || index >= sheet.rowCount) {
+      return null;
+    }
+    final coordinates = RangeCoordinates(
+      startRow: index,
+      endRow: index,
+      startColumn: 0,
+      endColumn: sheet.columnCount - 1,
+    );
+    return RowApi._(
+      commandManager: _commandManager,
+      sheetName: sheet.name,
+      coordinates: coordinates,
+    );
+  }
+
+  /// Retourne un wrapper sur une colonne (index 0-based).
+  ColumnApi? column(int index) {
+    final sheet = _resolveSheet();
+    if (index < 0 || index >= sheet.columnCount) {
+      return null;
+    }
+    final coordinates = RangeCoordinates(
+      startRow: 0,
+      endRow: sheet.rowCount - 1,
+      startColumn: index,
+      endColumn: index,
+    );
+    return ColumnApi._(
+      commandManager: _commandManager,
+      sheetName: sheet.name,
+      coordinates: coordinates,
+    );
+  }
+
+  /// Prépare un wrapper chart simple basé sur une plage.
+  ChartApi? chart(String reference) {
+    final rangeApi = range(reference);
+    if (rangeApi == null) {
+      return null;
+    }
+    return ChartApi._(rangeApi);
+  }
+
   bool _withActiveSheet(bool Function() action) {
     final pageIndex = _resolvePageIndex();
     if (pageIndex == null) {
@@ -304,5 +370,390 @@ class CellApi {
       return value;
     }
     return value.toString();
+  }
+}
+
+/// Coordonnées d'une plage rectangulaire.
+class RangeCoordinates {
+  RangeCoordinates({
+    required this.startRow,
+    required this.endRow,
+    required this.startColumn,
+    required this.endColumn,
+  })  : assert(startRow >= 0),
+        assert(endRow >= startRow),
+        assert(startColumn >= 0),
+        assert(endColumn >= startColumn);
+
+  final int startRow;
+  final int endRow;
+  final int startColumn;
+  final int endColumn;
+
+  int get rowCount => endRow - startRow + 1;
+  int get columnCount => endColumn - startColumn + 1;
+}
+
+class RangeApi {
+  RangeApi._({
+    required WorkbookCommandManager commandManager,
+    required this.sheetName,
+    required RangeCoordinates coordinates,
+  })  : _commandManager = commandManager,
+        _coordinates = coordinates;
+
+  final WorkbookCommandManager _commandManager;
+  final String sheetName;
+  RangeCoordinates _coordinates;
+  bool _lastResult = false;
+
+  RangeCoordinates get coordinates => _coordinates;
+
+  int get rowCount => _coordinates.rowCount;
+  int get columnCount => _coordinates.columnCount;
+
+  /// Résultat du dernier appel de mutation.
+  bool get lastResult => _lastResult;
+
+  /// Lecture synchrone des valeurs.
+  List<List<Object?>> get values {
+    final sheet = _resolveSheet();
+    final result = <List<Object?>>[];
+    for (var r = _coordinates.startRow; r <= _coordinates.endRow; r++) {
+      final row = <Object?>[];
+      for (var c = _coordinates.startColumn; c <= _coordinates.endColumn; c++) {
+        row.add(sheet.rows[r][c].value);
+      }
+      result.add(List<Object?>.unmodifiable(row));
+    }
+    return List<List<Object?>>.unmodifiable(result);
+  }
+
+  /// Met à jour la plage avec les valeurs fournies.
+  RangeApi setValues(List<List<Object?>> values) {
+    if (values.isEmpty) {
+      throw ArgumentError('values must not be empty.');
+    }
+    final expectedColumns = columnCount;
+    if (values.any((row) => row.length != expectedColumns)) {
+      throw ArgumentError('Chaque ligne doit contenir $expectedColumns éléments.');
+    }
+    if (values.length != rowCount) {
+      throw ArgumentError('Le nombre de lignes doit être $rowCount.');
+    }
+
+    _lastResult = _commandManager.execute(
+      SetRangeValuesCommand(
+        sheetName: sheetName,
+        startRow: _coordinates.startRow,
+        startColumn: _coordinates.startColumn,
+        values: values,
+      ),
+    );
+    return this;
+  }
+
+  /// Attribue une valeur unique lorsque la plage ne contient qu'une cellule.
+  RangeApi setValue(Object? value) {
+    if (rowCount != 1 || columnCount != 1) {
+      throw StateError('setValue ne peut être utilisé que sur une cellule.');
+    }
+    return setValues([
+      [value]
+    ]);
+  }
+
+  /// Efface le contenu de la plage.
+  RangeApi clear() {
+    final empty = List<List<Object?>>.generate(
+      rowCount,
+      (_) => List<Object?>.filled(columnCount, null),
+    );
+    return setValues(empty);
+  }
+
+  /// Recopie les données de la première ligne vers les suivantes.
+  RangeApi fillDown() {
+    _lastResult = _commandManager.execute(
+      AutoFillRangeCommand(
+        sheetName: sheetName,
+        startRow: _coordinates.startRow,
+        startColumn: _coordinates.startColumn,
+        rowCount: rowCount,
+        columnCount: columnCount,
+        direction: RangeFillDirection.down,
+      ),
+    );
+    return this;
+  }
+
+  /// Recopie les données de la première colonne vers les suivantes.
+  RangeApi fillRight() {
+    _lastResult = _commandManager.execute(
+      AutoFillRangeCommand(
+        sheetName: sheetName,
+        startRow: _coordinates.startRow,
+        startColumn: _coordinates.startColumn,
+        rowCount: rowCount,
+        columnCount: columnCount,
+        direction: RangeFillDirection.right,
+      ),
+    );
+    return this;
+  }
+
+  /// Trie les lignes de la plage.
+  RangeApi sortByColumn([int columnIndex = 0, bool ascending = true]) {
+    _lastResult = _commandManager.execute(
+      SortRangeCommand(
+        sheetName: sheetName,
+        startRow: _coordinates.startRow,
+        startColumn: _coordinates.startColumn,
+        rowCount: rowCount,
+        columnCount: columnCount,
+        columnOffset: columnIndex,
+        ascending: ascending,
+      ),
+    );
+    return this;
+  }
+
+  /// Convertit les cellules en valeurs numériques.
+  RangeApi formatAsNumber([int? decimalDigits]) {
+    _lastResult = _commandManager.execute(
+      FormatRangeAsNumberCommand(
+        sheetName: sheetName,
+        startRow: _coordinates.startRow,
+        startColumn: _coordinates.startColumn,
+        rowCount: rowCount,
+        columnCount: columnCount,
+        decimalDigits: decimalDigits,
+      ),
+    );
+    return this;
+  }
+
+  /// Nettoie les textes en supprimant les espaces superflus.
+  RangeApi autoFit() {
+    _lastResult = _commandManager.execute(
+      AutoFitRangeCommand(
+        sheetName: sheetName,
+        startRow: _coordinates.startRow,
+        startColumn: _coordinates.startColumn,
+        rowCount: rowCount,
+        columnCount: columnCount,
+      ),
+    );
+    return this;
+  }
+
+  Sheet _resolveSheet() {
+    final workbook = _commandManager.workbook;
+    for (final sheet in workbook.sheets) {
+      if (sheet.name == sheetName) {
+        return sheet;
+      }
+    }
+    throw StateError('Feuille introuvable : $sheetName');
+  }
+}
+
+class RowApi {
+  RowApi._({
+    required WorkbookCommandManager commandManager,
+    required this.sheetName,
+    required RangeCoordinates coordinates,
+  })  : _range = RangeApi._(
+          commandManager: commandManager,
+          sheetName: sheetName,
+          coordinates: coordinates,
+        ),
+        index = coordinates.startRow;
+
+  final String sheetName;
+  final RangeApi _range;
+
+  /// Index de la ligne dans la feuille.
+  final int index;
+
+  bool get lastResult => _range.lastResult;
+
+  /// Valeurs de la ligne.
+  List<Object?> get values => _range.values.first;
+
+  RowApi setValues(List<Object?> values) {
+    if (values.length != _range.columnCount) {
+      throw ArgumentError(
+        'La ligne $index attend ${_range.columnCount} valeurs.',
+      );
+    }
+    _range.setValues([values]);
+    return this;
+  }
+
+  RowApi fillRight() {
+    _range.fillRight();
+    return this;
+  }
+
+  RowApi formatAsNumber([int? decimalDigits]) {
+    _range.formatAsNumber(decimalDigits);
+    return this;
+  }
+
+  RowApi autoFit() {
+    _range.autoFit();
+    return this;
+  }
+
+  RangeApi asRange() => _range;
+}
+
+class ColumnApi {
+  ColumnApi._({
+    required WorkbookCommandManager commandManager,
+    required this.sheetName,
+    required RangeCoordinates coordinates,
+  })  : _range = RangeApi._(
+          commandManager: commandManager,
+          sheetName: sheetName,
+          coordinates: coordinates,
+        ),
+        index = coordinates.startColumn;
+
+  final String sheetName;
+  final RangeApi _range;
+
+  /// Index de la colonne dans la feuille.
+  final int index;
+
+  bool get lastResult => _range.lastResult;
+
+  List<Object?> get values {
+    final rows = _range.values;
+    return List<Object?>.unmodifiable([
+      for (final row in rows) row.first,
+    ]);
+  }
+
+  ColumnApi setValues(List<Object?> values) {
+    if (values.length != _range.rowCount) {
+      throw ArgumentError(
+        'La colonne $index attend ${_range.rowCount} valeurs.',
+      );
+    }
+    final matrix = [
+      for (final value in values) [value],
+    ];
+    _range.setValues(matrix);
+    return this;
+  }
+
+  ColumnApi fillDown() {
+    _range.fillDown();
+    return this;
+  }
+
+  ColumnApi formatAsNumber([int? decimalDigits]) {
+    _range.formatAsNumber(decimalDigits);
+    return this;
+  }
+
+  ColumnApi autoFit() {
+    _range.autoFit();
+    return this;
+  }
+
+  RangeApi asRange() => _range;
+}
+
+class ChartApi {
+  ChartApi._(this._sourceRange);
+
+  RangeApi _sourceRange;
+
+  RangeApi get range => _sourceRange;
+
+  ChartApi updateRange(RangeApi range) {
+    _sourceRange = range;
+    return this;
+  }
+
+  Map<String, Object?> describe() {
+    final coords = _sourceRange.coordinates;
+    return <String, Object?>{
+      'sheet': _sourceRange.sheetName,
+      'startRow': coords.startRow,
+      'endRow': coords.endRow,
+      'startColumn': coords.startColumn,
+      'endColumn': coords.endColumn,
+    };
+  }
+}
+
+class _RangeReferenceParser {
+  _RangeReferenceParser(this.sheet);
+
+  final Sheet sheet;
+
+  RangeCoordinates? parse(String reference) {
+    if (reference.isEmpty) {
+      return null;
+    }
+    final cleaned = reference.trim();
+    if (cleaned.isEmpty) {
+      return null;
+    }
+
+    final parts = cleaned.split(':');
+    if (parts.length == 1) {
+      final start = CellPosition.tryParse(parts.first);
+      if (start == null) {
+        return null;
+      }
+      if (!_withinSheet(start)) {
+        return null;
+      }
+      return RangeCoordinates(
+        startRow: start.row,
+        endRow: start.row,
+        startColumn: start.column,
+        endColumn: start.column,
+      );
+    }
+    if (parts.length == 2) {
+      final start = CellPosition.tryParse(parts.first);
+      final end = CellPosition.tryParse(parts.last);
+      if (start == null || end == null) {
+        return null;
+      }
+      if (!_withinSheet(start) || !_withinSheet(end)) {
+        return null;
+      }
+      final startRow = start.row < end.row ? start.row : end.row;
+      final endRow = start.row > end.row ? start.row : end.row;
+      final startColumn = start.column < end.column ? start.column : end.column;
+      final endColumn = start.column > end.column ? start.column : end.column;
+      return RangeCoordinates(
+        startRow: startRow,
+        endRow: endRow,
+        startColumn: startColumn,
+        endColumn: endColumn,
+      );
+    }
+    return null;
+  }
+
+  bool _withinSheet(CellPosition position) {
+    if (position.row < 0 || position.column < 0) {
+      return false;
+    }
+    if (position.row >= sheet.rowCount) {
+      return false;
+    }
+    if (position.column >= sheet.columnCount) {
+      return false;
+    }
+    return true;
   }
 }

--- a/lib/application/scripts/dart/dart_script_engine.dart
+++ b/lib/application/scripts/dart/dart_script_engine.dart
@@ -296,6 +296,10 @@ abstract class SheetApi {
   bool insertRow([int? index]);
   bool insertColumn([int? index]);
   bool clear();
+  RangeApi? range(String reference);
+  RowApi? row(int index);
+  ColumnApi? column(int index);
+  ChartApi? chart(String reference);
 }
 
 abstract class CellApi {
@@ -310,6 +314,53 @@ abstract class CellApi {
 
   bool setValue(Object? value);
   bool clear();
+}
+
+abstract class RangeApi {
+  int get rowCount;
+  int get columnCount;
+  bool get lastResult;
+  List<List<Object?>> get values;
+
+  RangeApi setValues(List<List<Object?>> values);
+  RangeApi setValue(Object? value);
+  RangeApi clear();
+  RangeApi fillDown();
+  RangeApi fillRight();
+  RangeApi sortByColumn([int columnIndex = 0, bool ascending = true]);
+  RangeApi formatAsNumber([int? decimalDigits]);
+  RangeApi autoFit();
+}
+
+abstract class RowApi {
+  int get index;
+  bool get lastResult;
+  List<Object?> get values;
+
+  RowApi setValues(List<Object?> values);
+  RowApi fillRight();
+  RowApi formatAsNumber([int? decimalDigits]);
+  RowApi autoFit();
+  RangeApi asRange();
+}
+
+abstract class ColumnApi {
+  int get index;
+  bool get lastResult;
+  List<Object?> get values;
+
+  ColumnApi setValues(List<Object?> values);
+  ColumnApi fillDown();
+  ColumnApi formatAsNumber([int? decimalDigits]);
+  ColumnApi autoFit();
+  RangeApi asRange();
+}
+
+abstract class ChartApi {
+  RangeApi get range;
+
+  ChartApi updateRange(RangeApi range);
+  Map<String, Object?> describe();
 }
 ''';
 
@@ -328,6 +379,10 @@ class _OptimaScriptPlugin implements EvalPlugin {
     registry.defineBridgeClass($WorkbookApi.$declaration);
     registry.defineBridgeClass($SheetApi.$declaration);
     registry.defineBridgeClass($CellApi.$declaration);
+    registry.defineBridgeClass($RangeApi.$declaration);
+    registry.defineBridgeClass($RowApi.$declaration);
+    registry.defineBridgeClass($ColumnApi.$declaration);
+    registry.defineBridgeClass($ChartApi.$declaration);
   }
 
   @override
@@ -348,6 +403,18 @@ class _OptimaScriptPlugin implements EvalPlugin {
     );
     runtime.addTypeAutowrapper(
       (value) => value is CellApi ? $CellApi.wrap(value) : null,
+    );
+    runtime.addTypeAutowrapper(
+      (value) => value is RangeApi ? $RangeApi.wrap(value) : null,
+    );
+    runtime.addTypeAutowrapper(
+      (value) => value is RowApi ? $RowApi.wrap(value) : null,
+    );
+    runtime.addTypeAutowrapper(
+      (value) => value is ColumnApi ? $ColumnApi.wrap(value) : null,
+    );
+    runtime.addTypeAutowrapper(
+      (value) => value is ChartApi ? $ChartApi.wrap(value) : null,
     );
   }
 }
@@ -886,6 +953,74 @@ class $SheetApi implements $Instance {
           ),
         ),
       ),
+      'range': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+            nullable: true,
+          ),
+          params: const [
+            BridgeParameter(
+              'reference',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(CoreTypes.string),
+              ),
+              false,
+            ),
+          ],
+        ),
+      ),
+      'row': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RowApi')),
+            nullable: true,
+          ),
+          params: const [
+            BridgeParameter(
+              'index',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(CoreTypes.int),
+              ),
+              false,
+            ),
+          ],
+        ),
+      ),
+      'column': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'ColumnApi')),
+            nullable: true,
+          ),
+          params: const [
+            BridgeParameter(
+              'index',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(CoreTypes.int),
+              ),
+              false,
+            ),
+          ],
+        ),
+      ),
+      'chart': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'ChartApi')),
+            nullable: true,
+          ),
+          params: const [
+            BridgeParameter(
+              'reference',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(CoreTypes.string),
+              ),
+              false,
+            ),
+          ],
+        ),
+      ),
     },
     getters: {
       'name': BridgeMethodDef(
@@ -945,6 +1080,14 @@ class $SheetApi implements $Instance {
         return _insertColumn;
       case 'clear':
         return _clear;
+      case 'range':
+        return _range;
+      case 'row':
+        return _row;
+      case 'column':
+        return _column;
+      case 'chart':
+        return _chart;
       default:
         return _superclass.$getProperty(runtime, identifier);
     }
@@ -1057,7 +1200,71 @@ class $SheetApi implements $Instance {
     return $bool(result);
   }
 
+  static const $Function _range = $Function(_invokeRange);
+
+  static $Value? _invokeRange(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $SheetApi;
+    final raw = args.isEmpty ? null : args[0]?.$reified;
+    if (raw == null) {
+      throw ArgumentError('range requiert une référence.');
+    }
+    final range = instance.$value.range(raw.toString());
+    return range == null ? const $null() : $RangeApi.wrap(range);
+  }
+
+  static const $Function _row = $Function(_invokeRow);
+
+  static $Value? _invokeRow(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $SheetApi;
+    final raw = args.isEmpty ? null : args[0]?.$reified;
+    if (raw is! int) {
+      throw ArgumentError('row attend un index entier.');
+    }
+    final row = instance.$value.row(raw);
+    return row == null ? const $null() : $RowApi.wrap(row);
+  }
+
+  static const $Function _column = $Function(_invokeColumn);
+
+  static $Value? _invokeColumn(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $SheetApi;
+    final raw = args.isEmpty ? null : args[0]?.$reified;
+    if (raw is! int) {
+      throw ArgumentError('column attend un index entier.');
+    }
+    final column = instance.$value.column(raw);
+    return column == null ? const $null() : $ColumnApi.wrap(column);
+  }
+
+  static const $Function _chart = $Function(_invokeChart);
+
+  static $Value? _invokeChart(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $SheetApi;
+    final raw = args.isEmpty ? null : args[0]?.$reified;
+    if (raw == null) {
+      throw ArgumentError('chart requiert une référence.');
+    }
+    final chart = instance.$value.chart(raw.toString());
+    return chart == null ? const $null() : $ChartApi.wrap(chart);
+  }
 }
+
 
 class $CellApi implements $Instance {
   $CellApi.wrap(this.$value) : _superclass = $Object($value);
@@ -1243,3 +1450,959 @@ class $CellApi implements $Instance {
     return $String(value.toString());
   }
 }
+
+class $RangeApi implements $Instance {
+  $RangeApi.wrap(this.$value) : _superclass = $Object($value);
+
+  static const $type = BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi'));
+
+  static final $declaration = BridgeClassDef(
+    BridgeClassType($type, isAbstract: true),
+    constructors: const {},
+    methods: {
+      'setValues': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+          ),
+          params: const [
+            BridgeParameter(
+              'values',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(
+                  CoreTypes.list,
+                  [
+                    BridgeTypeAnnotation(
+                      BridgeTypeRef(
+                        CoreTypes.list,
+                        [
+                          BridgeTypeAnnotation(
+                            BridgeTypeRef(CoreTypes.dynamic),
+                            nullable: true,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              false,
+            ),
+          ],
+        ),
+      ),
+      'setValue': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+          ),
+          params: const [
+            BridgeParameter(
+              'value',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(CoreTypes.dynamic),
+                nullable: true,
+              ),
+              false,
+            ),
+          ],
+        ),
+      ),
+      'clear': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+          ),
+        ),
+      ),
+      'fillDown': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+          ),
+        ),
+      ),
+      'fillRight': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+          ),
+        ),
+      ),
+      'sortByColumn': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+          ),
+          params: const [
+            BridgeParameter(
+              'columnIndex',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(CoreTypes.int),
+                nullable: true,
+              ),
+              true,
+            ),
+            BridgeParameter(
+              'ascending',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(CoreTypes.bool),
+                nullable: true,
+              ),
+              true,
+            ),
+          ],
+        ),
+      ),
+      'formatAsNumber': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+          ),
+          params: const [
+            BridgeParameter(
+              'decimalDigits',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(CoreTypes.int),
+                nullable: true,
+              ),
+              true,
+            ),
+          ],
+        ),
+      ),
+      'autoFit': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+          ),
+        ),
+      ),
+    },
+    getters: {
+      'rowCount': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(CoreTypes.int),
+          ),
+        ),
+      ),
+      'columnCount': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(CoreTypes.int),
+          ),
+        ),
+      ),
+      'lastResult': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(CoreTypes.bool),
+          ),
+        ),
+      ),
+      'values': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(
+              CoreTypes.list,
+              [
+                BridgeTypeAnnotation(
+                  BridgeTypeRef(
+                    CoreTypes.list,
+                    [
+                      BridgeTypeAnnotation(
+                        BridgeTypeRef(CoreTypes.dynamic),
+                        nullable: true,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    },
+    wrap: true,
+  );
+
+  @override
+  final RangeApi $value;
+
+  final $Instance _superclass;
+
+  @override
+  RangeApi get $reified => $value;
+
+  @override
+  int $getRuntimeType(Runtime runtime) => runtime.lookupType($type.spec!);
+
+  @override
+  $Value? $getProperty(Runtime runtime, String identifier) {
+    switch (identifier) {
+      case 'rowCount':
+        return $int($value.rowCount);
+      case 'columnCount':
+        return $int($value.columnCount);
+      case 'lastResult':
+        return $bool($value.lastResult);
+      case 'values':
+        return _wrapMatrix($value.values);
+      case 'setValues':
+        return _setValues;
+      case 'setValue':
+        return _setValue;
+      case 'clear':
+        return _clearRange;
+      case 'fillDown':
+        return _fillDown;
+      case 'fillRight':
+        return _fillRight;
+      case 'sortByColumn':
+        return _sortByColumn;
+      case 'formatAsNumber':
+        return _formatAsNumber;
+      case 'autoFit':
+        return _autoFit;
+      default:
+        return _superclass.$getProperty(runtime, identifier);
+    }
+  }
+
+  @override
+  void $setProperty(Runtime runtime, String identifier, $Value value) {
+    _superclass.$setProperty(runtime, identifier, value);
+  }
+
+  static const $Function _setValues = $Function(_invokeSetValues);
+
+  static $Value? _invokeSetValues(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RangeApi;
+    if (args.isEmpty) {
+      throw ArgumentError('setValues requiert une matrice.');
+    }
+    final matrixRaw = args[0];
+    final matrix = _reifyMatrix(matrixRaw);
+    final result = instance.$value.setValues(matrix);
+    return $RangeApi.wrap(result);
+  }
+
+  static const $Function _setValue = $Function(_invokeSetValue);
+
+  static $Value? _invokeSetValue(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RangeApi;
+    final raw = args.isEmpty ? null : args[0]?.$reified;
+    final result = instance.$value.setValue(raw);
+    return $RangeApi.wrap(result);
+  }
+
+  static const $Function _clearRange = $Function(_invokeClearRange);
+
+  static $Value? _invokeClearRange(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RangeApi;
+    final result = instance.$value.clear();
+    return $RangeApi.wrap(result);
+  }
+
+  static const $Function _fillDown = $Function(_invokeFillDown);
+
+  static $Value? _invokeFillDown(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RangeApi;
+    final result = instance.$value.fillDown();
+    return $RangeApi.wrap(result);
+  }
+
+  static const $Function _fillRight = $Function(_invokeFillRight);
+
+  static $Value? _invokeFillRight(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RangeApi;
+    final result = instance.$value.fillRight();
+    return $RangeApi.wrap(result);
+  }
+
+  static const $Function _sortByColumn = $Function(_invokeSortByColumn);
+
+  static $Value? _invokeSortByColumn(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RangeApi;
+    var columnIndex = 0;
+    var ascending = true;
+    if (args.isNotEmpty) {
+      final rawIndex = args[0]?.$reified;
+      if (rawIndex != null) {
+        if (rawIndex is! int) {
+          throw ArgumentError('sortByColumn attend un entier pour columnIndex.');
+        }
+        columnIndex = rawIndex;
+      }
+    }
+    if (args.length > 1) {
+      final rawAscending = args[1]?.$reified;
+      if (rawAscending != null) {
+        if (rawAscending is! bool) {
+          throw ArgumentError('sortByColumn attend un booléen pour ascending.');
+        }
+        ascending = rawAscending;
+      }
+    }
+    final result = instance.$value.sortByColumn(columnIndex, ascending);
+    return $RangeApi.wrap(result);
+  }
+
+  static const $Function _formatAsNumber = $Function(_invokeFormatAsNumber);
+
+  static $Value? _invokeFormatAsNumber(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RangeApi;
+    int? digits;
+    if (args.isNotEmpty) {
+      final rawDigits = args[0]?.$reified;
+      if (rawDigits != null) {
+        if (rawDigits is! int) {
+          throw ArgumentError('formatAsNumber attend un entier.');
+        }
+        digits = rawDigits;
+      }
+    }
+    final result = instance.$value.formatAsNumber(digits);
+    return $RangeApi.wrap(result);
+  }
+
+  static const $Function _autoFit = $Function(_invokeAutoFit);
+
+  static $Value? _invokeAutoFit(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RangeApi;
+    final result = instance.$value.autoFit();
+    return $RangeApi.wrap(result);
+  }
+
+  static $Value _wrapMatrix(List<List<Object?>> matrix) {
+    return wrapList<List<Object?>>(
+      matrix,
+      (row) => wrapList<Object?>(
+        row,
+        (value) => $CellApi._wrapValue(value) ?? const $null(),
+      ),
+    );
+  }
+
+  static List<List<Object?>> _reifyMatrix($Value? matrixValue) {
+    final reified = matrixValue?.$reified;
+    if (reified is! List) {
+      throw ArgumentError('setValues attend une liste de listes.');
+    }
+    final matrix = <List<Object?>>[];
+    for (final row in reified) {
+      matrix.add($ScriptContext._reifyList(row));
+    }
+    return matrix;
+  }
+}
+
+class $RowApi implements $Instance {
+  $RowApi.wrap(this.$value) : _superclass = $Object($value);
+
+  static const $type = BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RowApi'));
+
+  static final $declaration = BridgeClassDef(
+    BridgeClassType($type, isAbstract: true),
+    constructors: const {},
+    methods: {
+      'setValues': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RowApi')),
+          ),
+          params: const [
+            BridgeParameter(
+              'values',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(
+                  CoreTypes.list,
+                  [
+                    BridgeTypeAnnotation(
+                      BridgeTypeRef(CoreTypes.dynamic),
+                      nullable: true,
+                    ),
+                  ],
+                ),
+              ),
+              false,
+            ),
+          ],
+        ),
+      ),
+      'fillRight': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RowApi')),
+          ),
+        ),
+      ),
+      'formatAsNumber': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RowApi')),
+          ),
+          params: const [
+            BridgeParameter(
+              'decimalDigits',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(CoreTypes.int),
+                nullable: true,
+              ),
+              true,
+            ),
+          ],
+        ),
+      ),
+      'autoFit': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RowApi')),
+          ),
+        ),
+      ),
+      'asRange': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+          ),
+        ),
+      ),
+    },
+    getters: {
+      'index': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(CoreTypes.int),
+          ),
+        ),
+      ),
+      'lastResult': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(CoreTypes.bool),
+          ),
+        ),
+      ),
+      'values': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(
+              CoreTypes.list,
+              [
+                BridgeTypeAnnotation(
+                  BridgeTypeRef(CoreTypes.dynamic),
+                  nullable: true,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    },
+    wrap: true,
+  );
+
+  @override
+  final RowApi $value;
+
+  final $Instance _superclass;
+
+  @override
+  RowApi get $reified => $value;
+
+  @override
+  int $getRuntimeType(Runtime runtime) => runtime.lookupType($type.spec!);
+
+  @override
+  $Value? $getProperty(Runtime runtime, String identifier) {
+    switch (identifier) {
+      case 'index':
+        return $int($value.index);
+      case 'lastResult':
+        return $bool($value.lastResult);
+      case 'values':
+        return _wrapValues($value.values);
+      case 'setValues':
+        return _setValues;
+      case 'fillRight':
+        return _fillRight;
+      case 'formatAsNumber':
+        return _formatAsNumber;
+      case 'autoFit':
+        return _autoFit;
+      case 'asRange':
+        return _asRange;
+      default:
+        return _superclass.$getProperty(runtime, identifier);
+    }
+  }
+
+  @override
+  void $setProperty(Runtime runtime, String identifier, $Value value) {
+    _superclass.$setProperty(runtime, identifier, value);
+  }
+
+  static const $Function _setValues = $Function(_invokeSetValues);
+
+  static $Value? _invokeSetValues(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RowApi;
+    if (args.isEmpty) {
+      throw ArgumentError('setValues requiert une liste.');
+    }
+    final values = $ScriptContext._reifyList(args[0]?.$reified);
+    final result = instance.$value.setValues(values);
+    return $RowApi.wrap(result);
+  }
+
+  static const $Function _fillRight = $Function(_invokeFillRight);
+
+  static $Value? _invokeFillRight(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RowApi;
+    final result = instance.$value.fillRight();
+    return $RowApi.wrap(result);
+  }
+
+  static const $Function _formatAsNumber = $Function(_invokeFormatAsNumber);
+
+  static $Value? _invokeFormatAsNumber(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RowApi;
+    int? digits;
+    if (args.isNotEmpty) {
+      final rawDigits = args[0]?.$reified;
+      if (rawDigits != null) {
+        if (rawDigits is! int) {
+          throw ArgumentError('formatAsNumber attend un entier.');
+        }
+        digits = rawDigits;
+      }
+    }
+    final result = instance.$value.formatAsNumber(digits);
+    return $RowApi.wrap(result);
+  }
+
+  static const $Function _autoFit = $Function(_invokeAutoFit);
+
+  static $Value? _invokeAutoFit(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RowApi;
+    final result = instance.$value.autoFit();
+    return $RowApi.wrap(result);
+  }
+
+  static const $Function _asRange = $Function(_invokeAsRange);
+
+  static $Value? _invokeAsRange(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $RowApi;
+    final range = instance.$value.asRange();
+    return $RangeApi.wrap(range);
+  }
+
+  static $Value _wrapValues(List<Object?> values) {
+    return wrapList<Object?>(
+      values,
+      (value) => $CellApi._wrapValue(value) ?? const $null(),
+    );
+  }
+}
+
+class $ColumnApi implements $Instance {
+  $ColumnApi.wrap(this.$value) : _superclass = $Object($value);
+
+  static const $type = BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'ColumnApi'));
+
+  static final $declaration = BridgeClassDef(
+    BridgeClassType($type, isAbstract: true),
+    constructors: const {},
+    methods: {
+      'setValues': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'ColumnApi')),
+          ),
+          params: const [
+            BridgeParameter(
+              'values',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(
+                  CoreTypes.list,
+                  [
+                    BridgeTypeAnnotation(
+                      BridgeTypeRef(CoreTypes.dynamic),
+                      nullable: true,
+                    ),
+                  ],
+                ),
+              ),
+              false,
+            ),
+          ],
+        ),
+      ),
+      'fillDown': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'ColumnApi')),
+          ),
+        ),
+      ),
+      'formatAsNumber': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'ColumnApi')),
+          ),
+          params: const [
+            BridgeParameter(
+              'decimalDigits',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(CoreTypes.int),
+                nullable: true,
+              ),
+              true,
+            ),
+          ],
+        ),
+      ),
+      'autoFit': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'ColumnApi')),
+          ),
+        ),
+      ),
+      'asRange': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+          ),
+        ),
+      ),
+    },
+    getters: {
+      'index': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(CoreTypes.int),
+          ),
+        ),
+      ),
+      'lastResult': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(CoreTypes.bool),
+          ),
+        ),
+      ),
+      'values': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(
+              CoreTypes.list,
+              [
+                BridgeTypeAnnotation(
+                  BridgeTypeRef(CoreTypes.dynamic),
+                  nullable: true,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    },
+    wrap: true,
+  );
+
+  @override
+  final ColumnApi $value;
+
+  final $Instance _superclass;
+
+  @override
+  ColumnApi get $reified => $value;
+
+  @override
+  int $getRuntimeType(Runtime runtime) => runtime.lookupType($type.spec!);
+
+  @override
+  $Value? $getProperty(Runtime runtime, String identifier) {
+    switch (identifier) {
+      case 'index':
+        return $int($value.index);
+      case 'lastResult':
+        return $bool($value.lastResult);
+      case 'values':
+        return _wrapValues($value.values);
+      case 'setValues':
+        return _setValues;
+      case 'fillDown':
+        return _fillDown;
+      case 'formatAsNumber':
+        return _formatAsNumber;
+      case 'autoFit':
+        return _autoFit;
+      case 'asRange':
+        return _asRange;
+      default:
+        return _superclass.$getProperty(runtime, identifier);
+    }
+  }
+
+  @override
+  void $setProperty(Runtime runtime, String identifier, $Value value) {
+    _superclass.$setProperty(runtime, identifier, value);
+  }
+
+  static const $Function _setValues = $Function(_invokeSetValues);
+
+  static $Value? _invokeSetValues(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $ColumnApi;
+    if (args.isEmpty) {
+      throw ArgumentError('setValues requiert une liste.');
+    }
+    final values = $ScriptContext._reifyList(args[0]?.$reified);
+    final result = instance.$value.setValues(values);
+    return $ColumnApi.wrap(result);
+  }
+
+  static const $Function _fillDown = $Function(_invokeFillDown);
+
+  static $Value? _invokeFillDown(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $ColumnApi;
+    final result = instance.$value.fillDown();
+    return $ColumnApi.wrap(result);
+  }
+
+  static const $Function _formatAsNumber = $Function(_invokeFormatAsNumber);
+
+  static $Value? _invokeFormatAsNumber(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $ColumnApi;
+    int? digits;
+    if (args.isNotEmpty) {
+      final rawDigits = args[0]?.$reified;
+      if (rawDigits != null) {
+        if (rawDigits is! int) {
+          throw ArgumentError('formatAsNumber attend un entier.');
+        }
+        digits = rawDigits;
+      }
+    }
+    final result = instance.$value.formatAsNumber(digits);
+    return $ColumnApi.wrap(result);
+  }
+
+  static const $Function _autoFit = $Function(_invokeAutoFit);
+
+  static $Value? _invokeAutoFit(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $ColumnApi;
+    final result = instance.$value.autoFit();
+    return $ColumnApi.wrap(result);
+  }
+
+  static const $Function _asRange = $Function(_invokeAsRange);
+
+  static $Value? _invokeAsRange(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $ColumnApi;
+    final range = instance.$value.asRange();
+    return $RangeApi.wrap(range);
+  }
+
+  static $Value _wrapValues(List<Object?> values) {
+    return wrapList<Object?>(
+      values,
+      (value) => $CellApi._wrapValue(value) ?? const $null(),
+    );
+  }
+}
+
+class $ChartApi implements $Instance {
+  $ChartApi.wrap(this.$value) : _superclass = $Object($value);
+
+  static const $type = BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'ChartApi'));
+
+  static final $declaration = BridgeClassDef(
+    BridgeClassType($type, isAbstract: true),
+    constructors: const {},
+    methods: {
+      'updateRange': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'ChartApi')),
+          ),
+          params: const [
+            BridgeParameter(
+              'range',
+              BridgeTypeAnnotation(
+                BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+              ),
+              false,
+            ),
+          ],
+        ),
+      ),
+      'describe': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(
+              CoreTypes.map,
+              [
+                BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.string)),
+                BridgeTypeAnnotation(
+                  BridgeTypeRef(CoreTypes.dynamic),
+                  nullable: true,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    },
+    getters: {
+      'range': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(
+            BridgeTypeRef(BridgeTypeSpec(_apiLibraryUri, 'RangeApi')),
+          ),
+        ),
+      ),
+    },
+    wrap: true,
+  );
+
+  @override
+  final ChartApi $value;
+
+  final $Instance _superclass;
+
+  @override
+  ChartApi get $reified => $value;
+
+  @override
+  int $getRuntimeType(Runtime runtime) => runtime.lookupType($type.spec!);
+
+  @override
+  $Value? $getProperty(Runtime runtime, String identifier) {
+    switch (identifier) {
+      case 'range':
+        return $RangeApi.wrap($value.range);
+      case 'updateRange':
+        return _updateRange;
+      case 'describe':
+        return _describe;
+      default:
+        return _superclass.$getProperty(runtime, identifier);
+    }
+  }
+
+  @override
+  void $setProperty(Runtime runtime, String identifier, $Value value) {
+    _superclass.$setProperty(runtime, identifier, value);
+  }
+
+  static const $Function _updateRange = $Function(_invokeUpdateRange);
+
+  static $Value? _invokeUpdateRange(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $ChartApi;
+    if (args.isEmpty) {
+      throw ArgumentError('updateRange requiert une plage.');
+    }
+    final raw = args[0];
+    if (raw is! $RangeApi) {
+      throw ArgumentError('updateRange attend un RangeApi.');
+    }
+    final chart = instance.$value.updateRange(raw.$value);
+    return $ChartApi.wrap(chart);
+  }
+
+  static const $Function _describe = $Function(_invokeDescribe);
+
+  static $Value? _invokeDescribe(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) {
+    final instance = target as $ChartApi;
+    final description = instance.$value.describe();
+    return wrapMap<String, Object?>(
+      description,
+      (key) => $String(key),
+      (value) => $CellApi._wrapValue(value) ?? const $null(),
+    );
+  }
+}
+

--- a/test/application/commands/range_commands_test.dart
+++ b/test/application/commands/range_commands_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_application_1/application/commands/auto_fill_range_command.dart';
+import 'package:flutter_application_1/application/commands/auto_fit_range_command.dart';
+import 'package:flutter_application_1/application/commands/format_range_as_number_command.dart';
+import 'package:flutter_application_1/application/commands/set_range_values_command.dart';
+import 'package:flutter_application_1/application/commands/sort_range_command.dart';
+import 'package:flutter_application_1/application/commands/workbook_command.dart';
+import 'package:flutter_application_1/domain/sheet.dart';
+import 'package:flutter_application_1/domain/workbook.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+WorkbookCommandContext _buildContext(Sheet sheet) {
+  final workbook = Workbook(pages: [sheet]);
+  return WorkbookCommandContext(workbook: workbook, activePageIndex: 0);
+}
+
+Sheet _applyCommand(WorkbookCommand command, Sheet sheet) {
+  final context = _buildContext(sheet);
+  final result = command.execute(context);
+  expect(result.workbook.pages, hasLength(1));
+  expect(result.workbook.pages.first, isA<Sheet>());
+  return result.workbook.pages.first as Sheet;
+}
+
+void main() {
+  group('SetRangeValuesCommand', () {
+    test('applies values to the requested range', () {
+      final sheet = Sheet.fromRows(
+        name: 'Feuille 1',
+        rows: const <List<Object?>>[
+          <Object?>['A', 'B', 'C'],
+          <Object?>['D', 'E', 'F'],
+        ],
+      );
+      final command = SetRangeValuesCommand(
+        sheetName: sheet.name,
+        startRow: 0,
+        startColumn: 1,
+        values: const [
+          <Object?>['X', 'Y'],
+          <Object?>['Z', 'W'],
+        ],
+      );
+
+      final updated = _applyCommand(command, sheet);
+      expect(updated.rows[0][1].value, equals('X'));
+      expect(updated.rows[0][2].value, equals('Y'));
+      expect(updated.rows[1][1].value, equals('Z'));
+      expect(updated.rows[1][2].value, equals('W'));
+    });
+  });
+
+  group('AutoFillRangeCommand', () {
+    test('fills values downward from the first row', () {
+      final sheet = Sheet.fromRows(
+        name: 'Feuille 1',
+        rows: const <List<Object?>>[
+          <Object?>['src', 1],
+          <Object?>['', 0],
+          <Object?>['', 0],
+        ],
+      );
+      final command = AutoFillRangeCommand(
+        sheetName: sheet.name,
+        startRow: 0,
+        startColumn: 0,
+        rowCount: 3,
+        columnCount: 1,
+        direction: RangeFillDirection.down,
+      );
+
+      final updated = _applyCommand(command, sheet);
+      expect(updated.rows[1][0].value, equals('src'));
+      expect(updated.rows[2][0].value, equals('src'));
+    });
+
+    test('fills values to the right from the first column', () {
+      final sheet = Sheet.fromRows(
+        name: 'Feuille 1',
+        rows: const <List<Object?>>[
+          <Object?>['seed', '', ''],
+        ],
+      );
+      final command = AutoFillRangeCommand(
+        sheetName: sheet.name,
+        startRow: 0,
+        startColumn: 0,
+        rowCount: 1,
+        columnCount: 3,
+        direction: RangeFillDirection.right,
+      );
+
+      final updated = _applyCommand(command, sheet);
+      expect(updated.rows[0][1].value, equals('seed'));
+      expect(updated.rows[0][2].value, equals('seed'));
+    });
+  });
+
+  group('SortRangeCommand', () {
+    test('sorts rows by the provided column', () {
+      final sheet = Sheet.fromRows(
+        name: 'Feuille 1',
+        rows: const <List<Object?>>[
+          <Object?>['B', 2],
+          <Object?>['C', 3],
+          <Object?>['A', 1],
+        ],
+      );
+      final command = SortRangeCommand(
+        sheetName: sheet.name,
+        startRow: 0,
+        startColumn: 0,
+        rowCount: 3,
+        columnCount: 2,
+        columnOffset: 1,
+        ascending: false,
+      );
+
+      final updated = _applyCommand(command, sheet);
+      expect(updated.rows[0][0].value, equals('C'));
+      expect(updated.rows[1][0].value, equals('B'));
+      expect(updated.rows[2][0].value, equals('A'));
+    });
+  });
+
+  group('FormatRangeAsNumberCommand', () {
+    test('parses numeric strings and applies rounding', () {
+      final sheet = Sheet.fromRows(
+        name: 'Feuille 1',
+        rows: const <List<Object?>>[
+          <Object?>['12.345', 'invalid'],
+        ],
+      );
+      final command = FormatRangeAsNumberCommand(
+        sheetName: sheet.name,
+        startRow: 0,
+        startColumn: 0,
+        rowCount: 1,
+        columnCount: 2,
+        decimalDigits: 2,
+      );
+
+      final updated = _applyCommand(command, sheet);
+      expect(updated.rows[0][0].value, equals(12.35));
+      expect(updated.rows[0][1].value, equals('invalid'));
+    });
+  });
+
+  group('AutoFitRangeCommand', () {
+    test('trims surrounding whitespace for text values', () {
+      final sheet = Sheet.fromRows(
+        name: 'Feuille 1',
+        rows: const <List<Object?>>[
+          <Object?>['  spaced  ', ' ok '],
+        ],
+      );
+      final command = AutoFitRangeCommand(
+        sheetName: sheet.name,
+        startRow: 0,
+        startColumn: 0,
+        rowCount: 1,
+        columnCount: 2,
+      );
+
+      final updated = _applyCommand(command, sheet);
+      expect(updated.rows[0][0].value, equals('spaced'));
+      expect(updated.rows[0][1].value, equals('ok'));
+    });
+  });
+}

--- a/test/application/scripts/api/api_test.dart
+++ b/test/application/scripts/api/api_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_application_1/application/commands/workbook_command_manager.dart';
+import 'package:flutter_application_1/application/scripts/api/api.dart';
+import 'package:flutter_application_1/domain/sheet.dart';
+import 'package:flutter_application_1/domain/workbook.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+WorkbookCommandManager _buildManager() {
+  final sheet = Sheet.fromRows(
+    name: 'Feuille 1',
+    rows: const <List<Object?>>[
+      <Object?>['Nom', 'Statut', 'Score'],
+      <Object?>['Alice', '  actif ', '12.5'],
+      <Object?>['Bob', 'inactif', '7.3'],
+      <Object?>['Clara', 'actif', '9.4'],
+    ],
+  );
+  final workbook = Workbook(pages: [sheet]);
+  return WorkbookCommandManager(initialWorkbook: workbook);
+}
+
+void main() {
+  group('SheetApi range wrappers', () {
+    test('range returns values and supports chained mutations', () {
+      final manager = _buildManager();
+      final sheet = ScriptApi(commandManager: manager).workbook.activeSheet!;
+
+      final range = sheet.range('A2:C4');
+      expect(range, isNotNull);
+      expect(range!.values.length, equals(3));
+      expect(range.values.first.first, equals('Alice'));
+
+      range
+          .setValues(const [
+            <Object?>['Alice', 'actif', 14],
+            <Object?>['Bob', 'inactif', 7],
+            <Object?>['Clara', 'actif', 9],
+          ])
+          .formatAsNumber(null)
+          .sortByColumn(2, false)
+          .autoFit();
+
+      final updated = manager.workbook.sheets.first;
+      expect(updated.rows[0][2].value, equals('Score'));
+      expect(updated.rows[1][2].value, equals(9));
+      expect(updated.rows[2][1].value, equals('inactif'));
+      expect(updated.rows[1][1].value, equals('actif'));
+      expect(range.lastResult, isTrue);
+    });
+
+    test('fillDown copies top values to lower rows', () {
+      final manager = _buildManager();
+      final sheet = ScriptApi(commandManager: manager).workbook.activeSheet!;
+      final range = sheet.range('B2:B4');
+      expect(range, isNotNull);
+
+      range!.fillDown();
+
+      final updated = manager.workbook.sheets.first;
+      expect(updated.rows[1][1].value, equals('  actif '));
+      expect(updated.rows[2][1].value, equals('  actif '));
+      expect(updated.rows[3][1].value, equals('  actif '));
+    });
+  });
+
+  group('RowApi and ColumnApi helpers', () {
+    test('row allows inline updates and formatting', () {
+      final manager = _buildManager();
+      final sheet = ScriptApi(commandManager: manager).workbook.activeSheet!;
+
+      final row = sheet.row(1);
+      expect(row, isNotNull);
+      row!
+          .setValues(const <Object?>['Alice', 'active', '10.0'])
+          .formatAsNumber(null)
+          .autoFit();
+
+      final updated = manager.workbook.sheets.first;
+      expect(updated.rows[1][2].value, equals(10));
+      expect(updated.rows[1][1].value, equals('active'));
+      expect(row.lastResult, isTrue);
+    });
+
+    test('column supports fillDown and numeric formatting', () {
+      final manager = _buildManager();
+      final sheet = ScriptApi(commandManager: manager).workbook.activeSheet!;
+      final column = sheet.column(2);
+      expect(column, isNotNull);
+      column!
+          .setValues(const <Object?>['Score', '1.4', '2.6', '3.9'])
+          .formatAsNumber(1)
+          .fillDown();
+
+      final updated = manager.workbook.sheets.first;
+      expect(updated.rows[1][2].value, equals(1.4));
+      expect(updated.rows[2][2].value, equals(1.4));
+      expect(updated.rows[3][2].value, equals(1.4));
+    });
+
+    test('row/column return null when out of bounds', () {
+      final manager = _buildManager();
+      final sheet = ScriptApi(commandManager: manager).workbook.activeSheet!;
+      expect(sheet.row(-1), isNull);
+      expect(sheet.column(10), isNull);
+    });
+  });
+
+  group('ChartApi', () {
+    test('describe exposes source metadata', () {
+      final manager = _buildManager();
+      final sheet = ScriptApi(commandManager: manager).workbook.activeSheet!;
+      final chart = sheet.chart('A1:C4');
+      expect(chart, isNotNull);
+
+      final description = chart!.describe();
+      expect(description['sheet'], equals('Feuille 1'));
+      expect(description['startRow'], equals(0));
+      expect(description['endColumn'], equals(2));
+
+      chart.updateRange(sheet.range('A2:C4')!);
+      final next = chart.describe();
+      expect(next['startRow'], equals(1));
+    });
+  });
+}

--- a/test/application/scripts/dart_script_engine_test.dart
+++ b/test/application/scripts/dart_script_engine_test.dart
@@ -144,15 +144,25 @@ Future<void> onWorkbookOpen(ScriptContext context) async {
   final workbook = context.api.workbook;
   final second = workbook.sheetByName('Feuille 2');
   if (second != null) {
-    final cell = second.cellAt(0, 0);
-    if (cell.isEmpty) {
-      cell.setValue(42);
-    }
-    second.insertColumn();
+    second.range('A1:B1')?.setValues(const [
+      <Object?>['Nom', 'Actif'],
+    ]);
+    second.range('A2:A3')?.setValues(const [
+      <Object?>['Alice'],
+      <Object?>['Bob'],
+    ]);
+    second
+        .column(1)
+        ?.setValues(const <Object?>['Actif', '  Oui  ', 'Non '])
+        .autoFit();
+    second.range('C2:C3')?.setValues(const [
+      <Object?>['4.25'],
+      <Object?>[5.75],
+    ]).formatAsNumber(1);
   }
   if (workbook.activateSheetAt(1)) {
     final active = workbook.activeSheet;
-    active?.cellAt(0, 1).setValue(true);
+    active?.range('C2:C2')?.setValue(true);
   }
 }
 ''';
@@ -168,8 +178,22 @@ Future<void> onWorkbookOpen(ScriptContext context) async {
 
       final workbook = Workbook(
         pages: [
-          Sheet.fromRows(name: 'Feuille 1', rows: const [<Object?>[null]]),
-          Sheet.fromRows(name: 'Feuille 2', rows: const [<Object?>[null]]),
+          Sheet.fromRows(
+            name: 'Feuille 1',
+            rows: const [
+              <Object?>[null, null, null],
+              <Object?>[null, null, null],
+              <Object?>[null, null, null],
+            ],
+          ),
+          Sheet.fromRows(
+            name: 'Feuille 2',
+            rows: const [
+              <Object?>[null, null, null],
+              <Object?>[null, null, null],
+              <Object?>[null, null, null],
+            ],
+          ),
         ],
       );
       final manager = WorkbookCommandManager(initialWorkbook: workbook);
@@ -184,10 +208,14 @@ Future<void> onWorkbookOpen(ScriptContext context) async {
       await export!.call(context);
 
       final secondSheet = manager.workbook.sheets[1];
-      expect(secondSheet.rows.first.first.value, equals(42));
-      expect(secondSheet.columnCount, equals(2));
+      expect(secondSheet.rows[0][0].value, equals('Nom'));
+      expect(secondSheet.rows[0][1].value, equals('Actif'));
+      expect(secondSheet.rows[1][0].value, equals('Alice'));
+      expect(secondSheet.rows[1][1].value, equals('Oui'));
+      expect(secondSheet.rows[2][1].value, equals('Non'));
+      expect(secondSheet.rows[1][2].value, isTrue);
+      expect(secondSheet.rows[2][2].value, equals(5.8));
       expect(manager.activeSheetIndex, equals(1));
-      expect(secondSheet.rows.first[1].value, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Summary
- add dedicated commands for writing, filling, sorting, formatting and cleaning rectangular ranges
- expose RangeApi/RowApi/ColumnApi/ChartApi through the scripting bridge and extend documentation
- add unit tests covering the new commands and scripting surfaces

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2be1d164c8326b9996b4dd5e38fa5