### PR TITLE
Fix ChartApi describe wrapMap callback signature

### DIFF
--- a/lib/application/scripts/dart/dart_script_engine.dart
+++ b/lib/application/scripts/dart/dart_script_engine.dart
@@ -2400,8 +2400,10 @@ class $ChartApi implements $Instance {
     final description = instance.$value.describe();
     return wrapMap<String, Object?>(
       description,
-      (key) => $String(key),
-      (value) => $CellApi._wrapValue(value) ?? const $null(),
+      (key, value) => MapEntry<$Value, $Value>(
+        $String(key),
+        $CellApi._wrapValue(value) ?? const $null(),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- update the ChartApi describe bridge to return a MapEntry from wrapMap so it matches the expected callback signature

## Testing
- dart analyze *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c6432bd483269594b3a36a6d4ef8