### PR TITLE
Allow editing asset-backed scripts when filesystem is available

### DIFF
--- a/lib/presentation/workbook_navigator/script_editor_logic.dart
+++ b/lib/presentation/workbook_navigator/script_editor_logic.dart
@@ -332,20 +332,26 @@ mixin _ScriptEditorLogic on State<WorkbookNavigator> {
         return;
       }
       setState(() {
+        final supportsFileSystem = storage.supportsFileSystem;
+        final loadedFromAsset = stored?.origin.startsWith('asset:') ?? false;
+
         _currentScriptDescriptor = tab.descriptor;
         _suppressScriptEditorChanges = true;
         tab.controller.text = stored?.source ?? '';
         _suppressScriptEditorChanges = false;
         tab.isDirty = false;
-        tab.isMutable = stored?.isMutable ?? false;
+        tab.isMutable = stored?.isMutable ?? supportsFileSystem;
         if (stored == null) {
-          tab.status = storage.supportsFileSystem
+          tab.status = supportsFileSystem
               ? 'Script OptimaScript introuvable pour ${tab.descriptor.fileName}.'
               :
                   'Script OptimaScript introuvable et édition indisponible sur cette plateforme (lecture seule).';
         } else if (!tab.isMutable) {
           tab.status =
               'Script OptimaScript chargé depuis ${stored.origin}. Édition indisponible sur cette plateforme (lecture seule).';
+        } else if (loadedFromAsset && supportsFileSystem) {
+          tab.status =
+              'Script OptimaScript chargé depuis ${stored.origin}. Une copie modifiable sera créée lors de la sauvegarde.';
         } else {
           tab.status = createdFromTemplate
               ? 'Script OptimaScript absent. Modèle par défaut créé et sauvegardé (${stored.origin}).'

--- a/lib/presentation/workbook_navigator/script_editor_view.dart
+++ b/lib/presentation/workbook_navigator/script_editor_view.dart
@@ -42,20 +42,18 @@ extension _ScriptEditorView on _WorkbookNavigatorState {
           child: Stack(
             children: [
               Positioned.fill(
-                child: IgnorePointer(
-                  ignoring: !isMutable,
-                  child: TopAlignedCodeField(
-                    controller: controller,
-                    expands: true,
-                    textStyle: const TextStyle(
-                      fontFamily: 'monospace',
-                      fontSize: 13,
-                    ),
-                    lineNumberStyle: lineNumberStyle,
-                    padding: const EdgeInsets.all(12),
-                    background: theme.colorScheme.surface,
-                    textAlignVertical: TextAlignVertical.top,
+                child: TopAlignedCodeField(
+                  controller: controller,
+                  expands: true,
+                  textStyle: const TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 13,
                   ),
+                  lineNumberStyle: lineNumberStyle,
+                  padding: const EdgeInsets.all(12),
+                  background: theme.colorScheme.surface,
+                  textAlignVertical: TextAlignVertical.top,
+                  readOnly: !isMutable,
                 ),
               ),
               if (_scriptEditorLoading)


### PR DESCRIPTION
## Summary
- allow asset-backed script tabs to remain editable when the filesystem is available so users can type and save changes
- clarify the status message to explain that a writable copy will be created when editing asset-sourced scripts

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2d0ea5134832695fc8f3bd99fbf28