### PR TITLE
Fix script editor read-only state for asset scripts on writable platforms

### DIFF
--- a/lib/presentation/workbook_navigator/script_editor_logic.dart
+++ b/lib/presentation/workbook_navigator/script_editor_logic.dart
@@ -340,7 +340,8 @@ mixin _ScriptEditorLogic on State<WorkbookNavigator> {
         tab.controller.text = stored?.source ?? '';
         _suppressScriptEditorChanges = false;
         tab.isDirty = false;
-        tab.isMutable = stored?.isMutable ?? supportsFileSystem;
+        final canEdit = supportsFileSystem || (stored?.isMutable ?? false);
+        tab.isMutable = canEdit;
         if (stored == null) {
           tab.status = supportsFileSystem
               ? 'Script OptimaScript introuvable pour ${tab.descriptor.fileName}.'


### PR DESCRIPTION
## Summary
- allow script tabs backed by assets to remain editable when the filesystem is available

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d8a0fe048326901cab707b6384f4