### PR TITLE
Fix disposed line number controller updates

### DIFF
--- a/lib/presentation/widgets/top_aligned_code_field.dart
+++ b/lib/presentation/widgets/top_aligned_code_field.dart
@@ -108,11 +108,16 @@ class _TopAlignedCodeFieldState extends State<TopAlignedCodeField> {
     _numberScroll?.dispose();
     _codeScroll?.dispose();
     _numberController?.dispose();
+    _numberController = null;
     _keyboardVisibilitySubscription?.cancel();
     super.dispose();
   }
 
   void _onTextChanged() {
+    if (!mounted || _numberController == null) {
+      return;
+    }
+
     final str = widget.controller.text.split('\n');
     final buf = <String>[];
 


### PR DESCRIPTION
## Summary
- prevent `TopAlignedCodeField` from updating the line number controller after the widget is disposed
- clear the stored line number controller reference during dispose to avoid reuse once disposed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2dd9f2cdc8326bcea77131a67d6ab