### PR TITLE
Handle overflow in command ribbon and script editor

### DIFF
--- a/lib/presentation/widgets/command_ribbon.dart
+++ b/lib/presentation/widgets/command_ribbon.dart
@@ -65,36 +65,46 @@ class CommandRibbon extends StatelessWidget {
           ),
           child: Row(
             children: [
-              _ToolbarIconButton(
-                icon: Icons.undo,
-                tooltip: 'Annuler',
-                onPressed: commandManager.canUndo
-                    ? () {
-                        onBeforeCommand?.call();
-                        commandManager.undo();
-                      }
-                    : null,
-              ),
-              _ToolbarIconButton(
-                icon: Icons.redo,
-                tooltip: 'Retablir',
-                onPressed: commandManager.canRedo
-                    ? () {
-                        onBeforeCommand?.call();
-                        commandManager.redo();
-                      }
-                    : null,
+              Expanded(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      _ToolbarIconButton(
+                        icon: Icons.undo,
+                        tooltip: 'Annuler',
+                        onPressed: commandManager.canUndo
+                            ? () {
+                                onBeforeCommand?.call();
+                                commandManager.undo();
+                              }
+                            : null,
+                      ),
+                      _ToolbarIconButton(
+                        icon: Icons.redo,
+                        tooltip: 'Retablir',
+                        onPressed: commandManager.canRedo
+                            ? () {
+                                onBeforeCommand?.call();
+                                commandManager.redo();
+                              }
+                            : null,
+                      ),
+                      const SizedBox(width: 12),
+                      for (final menu in _menus) ...[
+                        _CommandMenu(
+                          config: menu,
+                          manager: commandManager,
+                          onBeforeCommand: onBeforeCommand,
+                        ),
+                        const SizedBox(width: 8),
+                      ],
+                    ],
+                  ),
+                ),
               ),
               const SizedBox(width: 12),
-              for (final menu in _menus) ...[
-                _CommandMenu(
-                  config: menu,
-                  manager: commandManager,
-                  onBeforeCommand: onBeforeCommand,
-                ),
-                const SizedBox(width: 8),
-              ],
-              const Spacer(),
               _ActivePageBadge(name: currentPageName),
             ],
           ),

--- a/lib/presentation/workbook_navigator/admin_workspace_view.dart
+++ b/lib/presentation/workbook_navigator/admin_workspace_view.dart
@@ -246,29 +246,53 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
     }
 
     Widget buildEditorContent({required bool fullscreen}) {
-      return Column(
+      final statusMessage = status;
+      final editorArea = fullscreen
+          ? Expanded(child: editorSurface)
+          : Flexible(fit: FlexFit.tight, child: editorSurface);
+
+      final content = Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           buildTabBar(),
           if (_scriptEditorTabs.isNotEmpty) const SizedBox(height: 8),
-          if (scriptFileName != null)
+          if (scriptFileName != null) ...[
             Text(
               'Fichier actuel : $scriptFileName',
               style: theme.textTheme.bodySmall,
             ),
-          if (scriptFileName != null) const SizedBox(height: 8),
-          if (_customActions.isNotEmpty) _buildCustomActionsBar(context),
-          if (_customActions.isNotEmpty) const SizedBox(height: 12),
-          if (fullscreen)
-            Expanded(child: editorSurface)
-          else
-            Flexible(fit: FlexFit.tight, child: editorSurface),
-          const SizedBox(height: 8),
-          if (status != null)
-            Text(
-              status,
-              style: theme.textTheme.bodySmall,
+            const SizedBox(height: 8),
+          ],
+          if (_customActions.isNotEmpty) ...[
+            _buildCustomActionsBar(context),
+            const SizedBox(height: 12),
+          ],
+          editorArea,
+        ],
+      );
+
+      if (statusMessage == null) {
+        return content;
+      }
+
+      return Stack(
+        children: [
+          Positioned.fill(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 32),
+              child: content,
             ),
+          ),
+          Align(
+            alignment: Alignment.bottomLeft,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                statusMessage,
+                style: theme.textTheme.bodySmall,
+              ),
+            ),
+          ),
         ],
       );
     }


### PR DESCRIPTION
## Summary
- wrap the command ribbon controls in a horizontal scroll view so they fit on narrow widths
- reposition the script editor status message to avoid flex overflows when space is tight

## Testing
- flutter analyze (fails: flutter not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e2ee1fd4748326a521d35e74f0ac9e