### PR TITLE
Fix line number column width to avoid wrapping digits

### DIFF
--- a/lib/presentation/widgets/top_aligned_code_field.dart
+++ b/lib/presentation/widgets/top_aligned_code_field.dart
@@ -78,6 +78,7 @@ class _TopAlignedCodeFieldState extends State<TopAlignedCodeField> {
   FocusNode? _focusNode;
   String? lines;
   String longestLine = '';
+  int _lineNumberDigits = 1;
 
   @override
   void initState() {
@@ -126,6 +127,7 @@ class _TopAlignedCodeFieldState extends State<TopAlignedCodeField> {
     }
 
     _numberController?.text = buf.join('\n');
+    _lineNumberDigits = max(1, buf.length.toString().length);
 
     longestLine = '';
     for (final line in widget.controller.text.split('\n')) {
@@ -213,6 +215,20 @@ class _TopAlignedCodeFieldState extends State<TopAlignedCodeField> {
     Container? numberCol;
 
     if (widget.lineNumbers) {
+      final digitSample = ''.padLeft(_lineNumberDigits, '0');
+      final textDirection = Directionality.of(context);
+      final digitPainter = TextPainter(
+        text: TextSpan(text: digitSample, style: numberTextStyle),
+        textDirection: textDirection,
+      )..layout();
+      const extraSpacing = 4.0;
+      final horizontalPadding =
+          widget.padding.left + widget.lineNumberStyle.margin / 2 + extraSpacing;
+      final computedNumberWidth = max<double>(
+        widget.lineNumberStyle.width,
+        digitPainter.width + horizontalPadding,
+      );
+
       lineNumberCol = TextField(
         smartQuotesType: widget.smartQuotesType,
         scrollPadding: widget.padding,
@@ -233,7 +249,7 @@ class _TopAlignedCodeFieldState extends State<TopAlignedCodeField> {
       );
 
       numberCol = Container(
-        width: widget.lineNumberStyle.width,
+        width: computedNumberWidth,
         padding: EdgeInsets.only(
           left: widget.padding.left,
           right: widget.lineNumberStyle.margin / 2,


### PR DESCRIPTION
## Summary
- track how many digits are required for the current line numbers
- measure the digit width and enlarge the number column so multi-digit values stay on a single line

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f875a3a08326ac40a41d76bf8bce