### PR TITLE
Remove unsupported TextField parameter in code field widget

### DIFF
--- a/lib/presentation/widgets/top_aligned_code_field.dart
+++ b/lib/presentation/widgets/top_aligned_code_field.dart
@@ -253,7 +253,6 @@ class _TopAlignedCodeFieldState extends State<TopAlignedCodeField> {
         selectionControls: widget.selectionControls,
         expands: widget.expands,
         scrollController: _numberScroll,
-        textWidthBasis: TextWidthBasis.longestLine,
         decoration: InputDecoration(
           disabledBorder: InputBorder.none,
           isDense: widget.isDense,


### PR DESCRIPTION
## Summary
- remove the unsupported `textWidthBasis` argument from the line-number TextField in `TopAlignedCodeField`

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2ff79a9d48326a808a8cb8122bdb5