### PR TITLE
Use CodeField wrapper for top-aligned script editor

### DIFF
--- a/lib/presentation/widgets/top_aligned_code_field.dart
+++ b/lib/presentation/widgets/top_aligned_code_field.dart
@@ -1,14 +1,9 @@
-import 'dart:async';
-import 'dart:math';
-
 import 'package:code_text_field/code_text_field.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:linked_scroll_controller/linked_scroll_controller.dart';
 
-/// A local copy of [CodeField] that exposes [textAlignVertical] so we can
-/// ensure the editable content stays anchored to the top of the editor.
-class TopAlignedCodeField extends StatefulWidget {
+/// Wraps the upstream [CodeField] to keep the rest of the codebase API stable
+/// while exposing a `textAlignVertical` toggle for expanded layouts.
+class TopAlignedCodeField extends StatelessWidget {
   const TopAlignedCodeField({
     super.key,
     required this.controller,
@@ -65,265 +60,71 @@ class TopAlignedCodeField extends StatefulWidget {
   final TextAlignVertical textAlignVertical;
 
   @override
-  State<TopAlignedCodeField> createState() => _TopAlignedCodeFieldState();
+  Widget build(BuildContext context) {
+    final editor = CodeField(
+      controller: controller,
+      minLines: minLines,
+      maxLines: maxLines,
+      expands: expands,
+      wrap: wrap,
+      background: background,
+      decoration: decoration,
+      textStyle: textStyle,
+      padding: padding,
+      lineNumberStyle: lineNumberStyle,
+      enabled: enabled,
+      onTap: onTap,
+      readOnly: readOnly,
+      cursorColor: cursorColor,
+      textSelectionTheme: textSelectionTheme,
+      lineNumberBuilder: lineNumberBuilder,
+      focusNode: focusNode,
+      onChanged: onChanged,
+      isDense: isDense,
+      smartQuotesType: smartQuotesType,
+      keyboardType: keyboardType,
+      lineNumbers: lineNumbers,
+      horizontalScroll: horizontalScroll,
+      selectionControls: selectionControls,
+    );
+
+    if (!expands || textAlignVertical == TextAlignVertical.top) {
+      return editor;
+    }
+
+    return _ExpandingAlignmentWrapper(
+      textAlignVertical: textAlignVertical,
+      child: editor,
+    );
+  }
 }
 
-class _TopAlignedCodeFieldState extends State<TopAlignedCodeField> {
-  LinkedScrollControllerGroup? _controllers;
-  ScrollController? _numberScroll;
-  ScrollController? _codeScroll;
-  LineNumberController? _numberController;
+class _ExpandingAlignmentWrapper extends StatelessWidget {
+  const _ExpandingAlignmentWrapper({
+    required this.textAlignVertical,
+    required this.child,
+  });
 
-  StreamSubscription<bool>? _keyboardVisibilitySubscription;
-  FocusNode? _focusNode;
-  String? lines;
-  String longestLine = '';
-  int _lineNumberDigits = 1;
-  int _lineCount = 1;
-
-  @override
-  void initState() {
-    super.initState();
-    _controllers = LinkedScrollControllerGroup();
-    _numberScroll = _controllers?.addAndGet();
-    _codeScroll = _controllers?.addAndGet();
-    _numberController = LineNumberController(widget.lineNumberBuilder);
-    widget.controller.addListener(_onTextChanged);
-    _focusNode = widget.focusNode ?? FocusNode();
-    _focusNode!.onKey = _onKey;
-    _focusNode!.attach(context, onKey: _onKey);
-
-    _onTextChanged();
-  }
-
-  KeyEventResult _onKey(FocusNode node, RawKeyEvent event) {
-    if (widget.readOnly) {
-      return KeyEventResult.ignored;
-    }
-
-    return widget.controller.onKey(event);
-  }
-
-  @override
-  void dispose() {
-    widget.controller.removeListener(_onTextChanged);
-    _numberScroll?.dispose();
-    _codeScroll?.dispose();
-    _numberController?.dispose();
-    _numberController = null;
-    _keyboardVisibilitySubscription?.cancel();
-    super.dispose();
-  }
-
-  void _onTextChanged() {
-    if (!mounted || _numberController == null) {
-      return;
-    }
-
-    final lines = widget.controller.text.split('\n');
-    final newLineCount = max(1, lines.length);
-    final newDigitWidth = max(1, newLineCount.toString().length);
-    final buf = <String>[];
-
-    for (var k = 0; k < lines.length; k++) {
-      buf.add((k + 1).toString().padLeft(newDigitWidth));
-    }
-
-    _numberController?.text = buf.join('\n');
-    _lineCount = newLineCount;
-    _lineNumberDigits = newDigitWidth;
-
-    longestLine = '';
-    for (final line in widget.controller.text.split('\n')) {
-      if (line.length > longestLine.length) {
-        longestLine = line;
-      }
-    }
-
-    setState(() {});
-  }
-
-  Widget _wrapInScrollView(
-    Widget codeField,
-    TextStyle textStyle,
-    double minWidth,
-  ) {
-    final leftPad = widget.lineNumberStyle.margin / 2;
-    final intrinsic = IntrinsicWidth(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          ConstrainedBox(
-            constraints: BoxConstraints(
-              maxHeight: 0,
-              minWidth: max(minWidth - leftPad, 0),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.only(right: 16),
-              child: Text(longestLine, style: textStyle),
-            ),
-          ),
-          widget.expands ? Expanded(child: codeField) : codeField,
-        ],
-      ),
-    );
-
-    return SingleChildScrollView(
-      padding: EdgeInsets.only(
-        left: leftPad,
-        right: widget.padding.right,
-      ),
-      scrollDirection: Axis.horizontal,
-      physics:
-          widget.horizontalScroll ? null : const NeverScrollableScrollPhysics(),
-      child: intrinsic,
-    );
-  }
+  final TextAlignVertical textAlignVertical;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    const rootKey = 'root';
-    final defaultBg = Colors.grey.shade900;
-    final defaultText = Colors.grey.shade200;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final hasHeight = constraints.hasBoundedHeight &&
+            constraints.maxHeight != double.infinity;
+        final align = Alignment(0, textAlignVertical.y.clamp(-1.0, 1.0));
 
-    final styles = CodeTheme.of(context)?.styles;
-    Color? backgroundCol =
-        widget.background ?? styles?[rootKey]?.backgroundColor ?? defaultBg;
+        if (!hasHeight) {
+          return Align(alignment: align, child: child);
+        }
 
-    if (widget.decoration != null) {
-      backgroundCol = null;
-    }
-
-    TextStyle textStyle = widget.textStyle ?? const TextStyle();
-    textStyle = textStyle.copyWith(
-      color: textStyle.color ?? styles?[rootKey]?.color ?? defaultText,
-      fontSize: textStyle.fontSize ?? 16.0,
-    );
-
-    TextStyle numberTextStyle =
-        widget.lineNumberStyle.textStyle ?? const TextStyle();
-    final numberColor =
-        (styles?[rootKey]?.color ?? defaultText).withOpacity(0.7);
-
-    numberTextStyle = numberTextStyle.copyWith(
-      color: numberTextStyle.color ?? numberColor,
-      fontSize: textStyle.fontSize,
-      fontFamily: textStyle.fontFamily,
-    );
-
-    final cursorColor =
-        widget.cursorColor ?? styles?[rootKey]?.color ?? defaultText;
-
-    TextField? lineNumberCol;
-    Container? numberCol;
-
-    if (widget.lineNumbers) {
-      final textDirection = Directionality.of(context);
-      final numberSampleSpan = widget.lineNumberBuilder?.call(
-            _lineCount,
-            numberTextStyle,
-          ) ??
-          TextSpan(
-            text: _lineCount.toString().padLeft(_lineNumberDigits),
-            style: numberTextStyle,
-          );
-      final digitPainter = TextPainter(
-        text: numberSampleSpan,
-        textDirection: textDirection,
-        textAlign: widget.lineNumberStyle.textAlign,
-        maxLines: 1,
-      )..layout();
-      const extraSpacing = 4.0;
-      final horizontalPadding =
-          widget.padding.left + widget.lineNumberStyle.margin / 2 + extraSpacing;
-      final computedNumberWidth = max<double>(
-        widget.lineNumberStyle.width,
-        digitPainter.width + horizontalPadding,
-      );
-
-      lineNumberCol = TextField(
-        smartQuotesType: widget.smartQuotesType,
-        scrollPadding: widget.padding,
-        style: numberTextStyle,
-        controller: _numberController,
-        enabled: false,
-        minLines: widget.minLines,
-        maxLines: widget.maxLines,
-        selectionControls: widget.selectionControls,
-        expands: widget.expands,
-        scrollController: _numberScroll,
-        decoration: InputDecoration(
-          disabledBorder: InputBorder.none,
-          isDense: widget.isDense,
-        ),
-        textAlign: widget.lineNumberStyle.textAlign,
-        textAlignVertical: widget.textAlignVertical,
-      );
-
-      numberCol = Container(
-        width: computedNumberWidth,
-        padding: EdgeInsets.only(
-          left: widget.padding.left,
-          right: widget.lineNumberStyle.margin / 2,
-        ),
-        color: widget.lineNumberStyle.background,
-        child: lineNumberCol,
-      );
-    }
-
-    final codeField = TextField(
-      keyboardType: widget.keyboardType,
-      smartQuotesType: widget.smartQuotesType,
-      focusNode: _focusNode,
-      onTap: widget.onTap,
-      scrollPadding: widget.padding,
-      style: textStyle,
-      controller: widget.controller,
-      minLines: widget.minLines,
-      selectionControls: widget.selectionControls,
-      maxLines: widget.maxLines,
-      expands: widget.expands,
-      scrollController: _codeScroll,
-      textAlignVertical: widget.textAlignVertical,
-      decoration: InputDecoration(
-        disabledBorder: InputBorder.none,
-        border: InputBorder.none,
-        focusedBorder: InputBorder.none,
-        isDense: widget.isDense,
-      ),
-      cursorColor: cursorColor,
-      autocorrect: false,
-      enableSuggestions: false,
-      enabled: widget.enabled,
-      onChanged: widget.onChanged,
-      readOnly: widget.readOnly,
-    );
-
-    final codeCol = Theme(
-      data: Theme.of(context).copyWith(
-        textSelectionTheme: widget.textSelectionTheme,
-      ),
-      child: LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constraints) {
-          return widget.wrap
-              ? codeField
-              : _wrapInScrollView(codeField, textStyle, constraints.maxWidth);
-        },
-      ),
-    );
-
-    return Container(
-      decoration: widget.decoration,
-      color: backgroundCol,
-      padding: !widget.lineNumbers ? const EdgeInsets.only(left: 8) : null,
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (widget.lineNumbers && numberCol != null) numberCol,
-          Expanded(child: codeCol),
-        ],
-      ),
+        return SizedBox(
+          height: constraints.maxHeight,
+          child: Align(alignment: align, child: child),
+        );
+      },
     );
   }
 }

--- a/lib/presentation/workbook_navigator/script_editor_view.dart
+++ b/lib/presentation/workbook_navigator/script_editor_view.dart
@@ -52,7 +52,6 @@ extension _ScriptEditorView on _WorkbookNavigatorState {
                   lineNumberStyle: lineNumberStyle,
                   padding: const EdgeInsets.all(12),
                   background: theme.colorScheme.surface,
-                  textAlignVertical: TextAlignVertical.top,
                   readOnly: !isMutable,
                 ),
               ),


### PR DESCRIPTION
## Summary
- replace the bespoke TextField implementation in TopAlignedCodeField with a thin wrapper around the upstream CodeField so syntax highlighting works again
- add an alignment helper so callers can still request vertical alignment when the field expands

## Testing
- not run (Flutter tooling unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e33737379883268dd39af03b916eac