### PR TITLE
Ensure expanding top-aligned code fields wrap for alignment

### DIFF
--- a/lib/presentation/widgets/top_aligned_code_field.dart
+++ b/lib/presentation/widgets/top_aligned_code_field.dart
@@ -88,7 +88,7 @@ class TopAlignedCodeField extends StatelessWidget {
       selectionControls: selectionControls,
     );
 
-    if (!expands || textAlignVertical == TextAlignVertical.top) {
+    if (!expands) {
       return editor;
     }
 


### PR DESCRIPTION
## Summary
- always wrap expanding code fields with the alignment wrapper so vertical alignment works for all positions

## Testing
- `flutter analyze` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3688546e88326947b611b77a9f9d1