### PR TITLE
Ensure admin script editor line numbers display correctly

### DIFF
--- a/lib/presentation/workbook_navigator/admin_workspace_view.dart
+++ b/lib/presentation/workbook_navigator/admin_workspace_view.dart
@@ -2,6 +2,10 @@ part of 'workbook_navigator.dart';
 
 const double _kWorkspaceToggleTabWidth = 36;
 const double _kWorkspaceToggleTabHeight = 48;
+const double _kLineNumberColumnWidth = 72;
+const double _kLineNumberMargin = 6;
+const int _kMinimumLineNumberDigits = 4;
+const String _kFigureSpace = '\u2007';
 const String _kWorkspaceToggleTooltip =
     'Afficher/Masquer l’espace de développement';
 
@@ -74,9 +78,13 @@ extension _AdminWorkspaceView on _WorkbookNavigatorState {
     final codeTheme = CodeThemeData(
       styles: isDark ? monokaiSublimeTheme : githubTheme,
     );
+    final lineNumberTextStyle = theme.textTheme.bodySmall?.copyWith(
+      fontFeatures: const [FontFeature.tabularFigures()],
+    );
     final lineNumberStyle = LineNumberStyle(
-      width: 48,
-      textStyle: theme.textTheme.bodySmall,
+      width: _kLineNumberColumnWidth,
+      margin: _kLineNumberMargin,
+      textStyle: lineNumberTextStyle,
     );
     final descriptor = _currentScriptDescriptor;
     final status = _scriptEditorStatus;

--- a/lib/presentation/workbook_navigator/script_editor_view.dart
+++ b/lib/presentation/workbook_navigator/script_editor_view.dart
@@ -35,6 +35,18 @@ extension _ScriptEditorView on _WorkbookNavigatorState {
         );
       }
 
+      TextSpan buildLineNumber(int line, TextStyle? style) {
+        final digits = line.toString();
+        final resolvedStyle = style ??
+            theme.textTheme.bodySmall?.copyWith(
+              fontFeatures: const [FontFeature.tabularFigures()],
+            );
+        final padded = digits.length >= _kMinimumLineNumberDigits
+            ? digits
+            : digits.padLeft(_kMinimumLineNumberDigits, _kFigureSpace);
+        return TextSpan(text: padded, style: resolvedStyle);
+      }
+
       final field = CodeTheme(
         data: codeTheme,
         child: DecoratedBox(
@@ -50,6 +62,7 @@ extension _ScriptEditorView on _WorkbookNavigatorState {
                     fontSize: 13,
                   ),
                   lineNumberStyle: lineNumberStyle,
+                  lineNumberBuilder: buildLineNumber,
                   padding: const EdgeInsets.all(12),
                   background: theme.colorScheme.surface,
                   readOnly: !isMutable,

--- a/lib/presentation/workbook_navigator/workbook_navigator.dart
+++ b/lib/presentation/workbook_navigator/workbook_navigator.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui' show FontFeature;
 
 import 'package:code_text_field/code_text_field.dart';
 import 'package:flutter/foundation.dart';


### PR DESCRIPTION
## Summary
- widen the admin script editor line-number column and enforce tabular figures so four-digit counts fit after the padded gutter
- render line numbers with figure-space padding to keep multi-digit values on a single row within the column

## Testing
- `flutter analyze` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e39b86d3688326a31b7b76cdd81310