### PR TITLE
Fix script editor line number sync when controller changes

### DIFF
--- a/lib/presentation/widgets/top_aligned_code_field.dart
+++ b/lib/presentation/widgets/top_aligned_code_field.dart
@@ -188,6 +188,24 @@ class _CodeFieldWithAlignmentState extends State<_CodeFieldWithAlignment> {
     _onTextChanged();
   }
 
+  @override
+  void didUpdateWidget(covariant _CodeFieldWithAlignment oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onTextChanged);
+      widget.controller.addListener(_onTextChanged);
+      _onTextChanged();
+    }
+
+    if (oldWidget.lineNumberBuilder != widget.lineNumberBuilder) {
+      final oldController = _numberController;
+      _numberController = LineNumberController(widget.lineNumberBuilder);
+      oldController?.dispose();
+      _onTextChanged();
+    }
+  }
+
   KeyEventResult _onKey(FocusNode node, RawKeyEvent event) {
     if (widget.readOnly) {
       return KeyEventResult.ignored;


### PR DESCRIPTION
## Summary
- ensure the script editor's TopAlignedCodeField reattaches listeners when the underlying code controller changes
- recreate the line-number controller when a different line-number builder is provided so counts stay accurate

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3a349ce8c8326a132d64b37b3530c