### PR TITLE
Handle script runtime errors without crashing

### DIFF
--- a/lib/application/scripts/runtime.dart
+++ b/lib/application/scripts/runtime.dart
@@ -312,7 +312,6 @@ class ScriptRuntime {
           ),
         ),
       );
-      Error.throwWithStackTrace(error, stackTrace);
     }
   }
 

--- a/test/application/scripts/script_runtime_test.dart
+++ b/test/application/scripts/script_runtime_test.dart
@@ -161,7 +161,7 @@ void main() {
       expect(invoked, isTrue);
     });
 
-    test('propagates errors thrown by callbacks with formatted logs', () async {
+    test('logs errors thrown by callbacks without crashing', () async {
       final storage = _InMemoryScriptStorage();
       final descriptor = const ScriptDescriptor(scope: ScriptScope.global, key: 'default');
       storage.addScript(
@@ -189,10 +189,7 @@ void main() {
         FlutterError.onError = previousOnError;
       });
 
-      await expectLater(
-        runtime.dispatchWorkbookOpen(),
-        throwsA(isA<StateError>()),
-      );
+      await runtime.dispatchWorkbookOpen();
 
       expect(logs, isNotEmpty);
       expect(logs.first, contains('Erreur script détectée'));


### PR DESCRIPTION
## Summary
- prevent script callbacks from rethrowing errors so runtime failures no longer crash page loading
- adjust the script runtime test to expect logged errors instead of propagated exceptions

## Testing
- Not run (Flutter SDK unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e541ef0a288326b95d08360ec4b307