### PR TITLE
Disable automatic workbook autosave

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -161,7 +161,6 @@ class _MyAppState extends State<MyApp> {
     if (commandManager.workbookRevision <= _lastSavedRevision) {
       return;
     }
-    _queueSave();
   }
 
   Future<void> _queueSave({bool showFeedback = false, BuildContext? context}) {

--- a/test/main_save_behavior_test.dart
+++ b/test/main_save_behavior_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_application_1/application/commands/set_cell_value_command.dart';
@@ -60,8 +61,16 @@ void main() {
     await tester.pump(const Duration(milliseconds: 10));
     await tester.pumpAndSettle();
 
+    expect(storage.saveCallCount, 0,
+        reason: 'Cell edit should not trigger a workbook save automatically');
+
+    await tester.tap(find.byIcon(Icons.save_outlined));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+    await tester.pumpAndSettle();
+
     expect(storage.saveCallCount, 1,
-        reason: 'Cell edit should trigger a workbook save');
+        reason: 'Manual save should persist workbook changes');
   });
 }
 


### PR DESCRIPTION
## Summary
- stop automatically queueing workbook saves when the command manager changes
- rely on the existing toolbar button for manual saves and adjust expectations in the save behavior test
- import the material icon definitions needed by the updated test

## Testing
- flutter test test/main_save_behavior_test.dart *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e54cc4eacc8326be569e5e0536ccb6